### PR TITLE
feat: notify on item-level changes (reviewer / CI / merge / updated_at)

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -467,6 +467,15 @@ pub async fn fetch_watched(
 
     // Walk alias results in a stable order (s0, s1, ...) so the primary
     // `involves:@me` query always gets first crack at each id.
+    let items = merge_search_results(data);
+    Ok(items)
+}
+
+/// Collapse the alias-keyed map returned by GraphQL search (s0, s1, …) into
+/// a single deduplicated, updated_at-desc-sorted list of items. Walking the
+/// aliases in name order gives the primary `involves:@me` query (s0) first
+/// dibs on each id, so the later watched-org queries don't clobber it.
+fn merge_search_results(data: std::collections::HashMap<String, SearchResult>) -> Vec<WatchedItem> {
     let mut ordered: Vec<(String, SearchResult)> = data.into_iter().collect();
     ordered.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -487,11 +496,8 @@ pub async fn fetch_watched(
         }
     }
 
-    // GraphQL search has no server-side sort for ISSUE type; order by
-    // updated_at descending so the UI mirrors the previous REST behaviour.
     items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-
-    Ok(items)
+    items
 }
 
 // ---------------------------------------------------------------------------
@@ -913,6 +919,159 @@ mod tests {
         // Fragments are defined once and referenced from aliases
         assert!(q.contains("fragment PrFields on PullRequest"));
         assert!(q.contains("...PrFields"));
+    }
+
+    fn make_issue_node(database_id: u64, repo: &str, number: u64) -> IssueNode {
+        serde_json::from_value(json!({
+            "databaseId": database_id,
+            "title": "issue title",
+            "number": number,
+            "url": format!("https://github.com/{repo}/issues/{number}"),
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "state": "OPEN",
+            "comments": { "totalCount": 0 },
+            "repository": { "nameWithOwner": repo },
+            "author": { "login": "someone", "avatarUrl": "a" }
+        }))
+        .unwrap()
+    }
+
+    fn make_pr_node(database_id: u64, repo: &str, number: u64, updated_at: &str) -> PrNode {
+        serde_json::from_value(json!({
+            "databaseId": database_id,
+            "title": "pr title",
+            "number": number,
+            "url": format!("https://github.com/{repo}/pull/{number}"),
+            "updatedAt": updated_at,
+            "state": "OPEN",
+            "comments": { "totalCount": 0 },
+            "repository": { "nameWithOwner": repo },
+            "author": { "login": "someone", "avatarUrl": "a" },
+            "reviews": { "nodes": [] },
+            "reviewRequests": { "nodes": [] },
+            "commits": { "nodes": [] }
+        }))
+        .unwrap()
+    }
+
+    fn search_result(nodes: Vec<SearchNode>) -> SearchResult {
+        SearchResult {
+            nodes: nodes.into_iter().map(Some).collect(),
+        }
+    }
+
+    #[test]
+    fn issue_to_item_copies_scalar_fields() {
+        let item = issue_to_item(make_issue_node(10, "o/r", 7));
+        assert_eq!(item.id, 10);
+        assert_eq!(item.kind, "issue");
+        assert_eq!(item.number, 7);
+        assert_eq!(item.repo, "o/r");
+        assert_eq!(item.state, "open");
+        assert!(!item.is_draft);
+        assert!(item.reviewers.is_empty());
+        assert!(item.ci_status.is_none());
+    }
+
+    #[test]
+    fn merge_search_results_sorts_by_updated_at_desc() {
+        let mut data = std::collections::HashMap::new();
+        data.insert(
+            "s0".to_string(),
+            search_result(vec![
+                SearchNode::PullRequest(make_pr_node(1, "o/r", 1, "2026-03-01T00:00:00Z")),
+                SearchNode::PullRequest(make_pr_node(2, "o/r", 2, "2026-04-01T00:00:00Z")),
+            ]),
+        );
+        let out = merge_search_results(data);
+        // Newer first
+        assert_eq!(out[0].id, 2);
+        assert_eq!(out[1].id, 1);
+    }
+
+    #[test]
+    fn merge_search_results_dedups_by_id_across_aliases() {
+        let mut data = std::collections::HashMap::new();
+        // The same PR appears in both queries (e.g. a user's own PR is in
+        // involves:@me and user:@me). Later alias must not clobber the one
+        // from the primary query.
+        data.insert(
+            "s0".to_string(),
+            search_result(vec![SearchNode::PullRequest(make_pr_node(
+                1,
+                "o/r",
+                1,
+                "2026-04-01T00:00:00Z",
+            ))]),
+        );
+        data.insert(
+            "s1".to_string(),
+            search_result(vec![SearchNode::PullRequest(make_pr_node(
+                1,
+                "o/r",
+                1,
+                "2026-04-01T00:00:00Z",
+            ))]),
+        );
+        let out = merge_search_results(data);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, 1);
+    }
+
+    #[test]
+    fn merge_search_results_mixes_prs_and_issues() {
+        let mut data = std::collections::HashMap::new();
+        data.insert(
+            "s0".to_string(),
+            search_result(vec![
+                SearchNode::PullRequest(make_pr_node(1, "o/r", 1, "2026-04-02T00:00:00Z")),
+                SearchNode::Issue(make_issue_node(2, "o/r", 2)),
+            ]),
+        );
+        let out = merge_search_results(data);
+        assert_eq!(out.len(), 2);
+        let kinds: Vec<_> = out.iter().map(|i| i.kind).collect();
+        assert!(kinds.contains(&"pr"));
+        assert!(kinds.contains(&"issue"));
+    }
+
+    #[test]
+    fn merge_search_results_skips_unknown_nodes() {
+        let mut data = std::collections::HashMap::new();
+        data.insert(
+            "s0".to_string(),
+            search_result(vec![
+                SearchNode::Unknown,
+                SearchNode::PullRequest(make_pr_node(1, "o/r", 1, "2026-04-01T00:00:00Z")),
+                SearchNode::Unknown,
+            ]),
+        );
+        let out = merge_search_results(data);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, 1);
+    }
+
+    #[test]
+    fn merge_search_results_drops_none_slots_in_nodes() {
+        // A search page can contain explicit null entries in GraphQL; Option<SearchNode>
+        // lets serde deserialize those as None and merge should ignore them.
+        let data = std::collections::HashMap::from([(
+            "s0".to_string(),
+            SearchResult {
+                nodes: vec![
+                    None,
+                    Some(SearchNode::PullRequest(make_pr_node(
+                        1,
+                        "o/r",
+                        1,
+                        "2026-04-01T00:00:00Z",
+                    ))),
+                    None,
+                ],
+            },
+        )]);
+        let out = merge_search_results(data);
+        assert_eq!(out.len(), 1);
     }
 
     #[test]

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { WatchedItem } from "./types";
 import {
+  computeItemChanges,
+  describeItemChange,
   filterVisible,
   groupByRepo,
   itemKey,
@@ -128,6 +130,151 @@ describe("groupByRepo", () => {
     const unread = new Set([1, 3]);
     const groups = groupByRepo(items, (i) => unread.has(i.id));
     expect(groups[0].unreadCount).toBe(2);
+  });
+});
+
+describe("describeItemChange", () => {
+  const base = makeItem({ id: 1, repo: "o/r", number: 1 });
+
+  it("returns null when nothing interesting changed", () => {
+    expect(describeItemChange(base, { ...base })).toBeNull();
+  });
+
+  it("reports state transitions first", () => {
+    expect(
+      describeItemChange(base, { ...base, state: "merged", updated_at: "t2" }),
+    ).toBe("Now merged");
+  });
+
+  it("reports draft becoming ready", () => {
+    const prev = { ...base, is_draft: true };
+    const curr = { ...base, is_draft: false, updated_at: "t2" };
+    expect(describeItemChange(prev, curr)).toBe("Ready for review");
+  });
+
+  it("reports ready becoming draft", () => {
+    const prev = { ...base, is_draft: false };
+    const curr = { ...base, is_draft: true, updated_at: "t2" };
+    expect(describeItemChange(prev, curr)).toBe("Marked as draft");
+  });
+
+  it("reports CI status change", () => {
+    const prev = { ...base, ci_status: "pending" as const };
+    const curr = { ...base, ci_status: "failure" as const, updated_at: "t2" };
+    expect(describeItemChange(prev, curr)).toBe("CI failure");
+  });
+
+  it("reports the first reviewer whose state shifted", () => {
+    const prev = {
+      ...base,
+      reviewers: [
+        { login: "alice", avatar_url: "", state: "pending" as const },
+      ],
+    };
+    const curr = {
+      ...base,
+      updated_at: "t2",
+      reviewers: [
+        { login: "alice", avatar_url: "", state: "approved" as const },
+      ],
+    };
+    expect(describeItemChange(prev, curr)).toBe("alice approved");
+  });
+
+  it("reports comment growth with pluralisation", () => {
+    expect(
+      describeItemChange(base, { ...base, comments: 1, updated_at: "t2" }),
+    ).toBe("+1 comment");
+    expect(
+      describeItemChange(base, { ...base, comments: 3, updated_at: "t2" }),
+    ).toBe("+3 comments");
+  });
+
+  it("falls back to Updated when only updated_at moved", () => {
+    expect(describeItemChange(base, { ...base, updated_at: "t2" })).toBe(
+      "Updated",
+    );
+  });
+});
+
+describe("computeItemChanges", () => {
+  it("returns empty when nothing changed and prev is seeded", () => {
+    const item = makeItem({ id: 1, repo: "o/r", number: 1 });
+    const prev = new Map([[1, item]]);
+    const out = computeItemChanges(prev, [item], new Set());
+    expect(out).toEqual([]);
+  });
+
+  it("flags new items as 'New in list'", () => {
+    const item = makeItem({ id: 1, repo: "o/r", number: 1 });
+    const out = computeItemChanges(new Map(), [item], new Set());
+    expect(out).toHaveLength(1);
+    expect(out[0].reason).toBe("New in list");
+    expect(out[0].item.id).toBe(1);
+  });
+
+  it("reuses describeItemChange reason for modified items", () => {
+    const prev = makeItem({ id: 1, repo: "o/r", number: 1 });
+    const curr = { ...prev, state: "merged", updated_at: "t2" };
+    const out = computeItemChanges(
+      new Map([[1, prev]]),
+      [curr],
+      new Set(),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].reason).toBe("Now merged");
+  });
+
+  it("skips items whose key is in notifiedKeys", () => {
+    // Imagine a GitHub notification thread already covers this PR; we
+    // should not fire a second "Updated" notification for the same event.
+    const prev = makeItem({ id: 1, repo: "o/r", kind: "pr", number: 1 });
+    const curr = { ...prev, updated_at: "t2" };
+    const notifiedKeys = new Set(["o/r:pr:1"]);
+    const out = computeItemChanges(
+      new Map([[1, prev]]),
+      [curr],
+      notifiedKeys,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("notifiedKeys skip applies to new items too", () => {
+    // A brand-new PR that GitHub already delivered via /notifications
+    // should not also show up as "New in list".
+    const item = makeItem({ id: 1, repo: "o/r", kind: "pr", number: 1 });
+    const out = computeItemChanges(
+      new Map(),
+      [item],
+      new Set(["o/r:pr:1"]),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("combines new + changed + untouched + notified in one pass", () => {
+    const a = makeItem({ id: 1, repo: "o/r", kind: "pr", number: 1 });
+    const b = makeItem({ id: 2, repo: "o/r", kind: "pr", number: 2 });
+    const c = makeItem({ id: 3, repo: "o/r", kind: "pr", number: 3 });
+    const d = makeItem({ id: 4, repo: "o/r", kind: "pr", number: 4 });
+
+    const prev = new Map([
+      [1, a],
+      [2, b],
+      [3, c],
+      // #4 didn't exist yet
+    ]);
+    const curr = [
+      { ...a }, // unchanged
+      { ...b, state: "closed", updated_at: "t2" }, // changed
+      { ...c, updated_at: "t2" }, // changed, but notified
+      d, // new
+    ];
+    const notifiedKeys = new Set(["o/r:pr:3"]);
+
+    const out = computeItemChanges(prev, curr, notifiedKeys);
+    expect(out).toHaveLength(2);
+    expect(out.find((c) => c.item.id === 2)?.reason).toBe("Now closed");
+    expect(out.find((c) => c.item.id === 4)?.reason).toBe("New in list");
   });
 });
 

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -70,3 +70,89 @@ export function repoSuggestionsFrom(
   }
   return [...seen].sort();
 }
+
+export type ItemChange = {
+  item: WatchedItem;
+  reason: string;
+};
+
+/**
+ * Compare a previous snapshot of the item list against a fresh fetch and
+ * produce one ItemChange per item that meaningfully moved (new entries, or
+ * anything describeItemChange cares about). Items whose (repo, kind, number)
+ * is already covered by a GitHub notification thread in `notifiedKeys` are
+ * skipped — the /notifications diff gets first dibs on surfacing them, so
+ * we don't fire two desktop notifications for the same underlying event.
+ */
+export function computeItemChanges(
+  prevItems: ReadonlyMap<number, WatchedItem>,
+  currItems: readonly WatchedItem[],
+  notifiedKeys: ReadonlySet<string>,
+): ItemChange[] {
+  const out: ItemChange[] = [];
+  for (const item of currItems) {
+    if (notifiedKeys.has(itemKey(item))) continue;
+    const prev = prevItems.get(item.id);
+    if (!prev) {
+      out.push({ item, reason: "New in list" });
+      continue;
+    }
+    const reason = describeItemChange(prev, item);
+    if (reason) out.push({ item, reason });
+  }
+  return out;
+}
+
+/**
+ * Describe what meaningfully changed between two snapshots of the same item,
+ * as a short phrase suitable for a desktop-notification title. Returns null
+ * when nothing interesting changed (i.e. not worth notifying about).
+ *
+ * Order matters — we return the first signal we find, roughly ranked by how
+ * actionable the change is: CI failures are louder than a label tweak.
+ */
+export function describeItemChange(
+  prev: WatchedItem,
+  curr: WatchedItem,
+): string | null {
+  // PR state transitions (merged / closed / reopened) are the biggest news.
+  if (prev.state !== curr.state) {
+    return `Now ${curr.state}`;
+  }
+
+  // Draft ⇄ ready is a reviewer-relevant flip.
+  if (prev.is_draft !== curr.is_draft) {
+    return curr.is_draft ? "Marked as draft" : "Ready for review";
+  }
+
+  // CI state change (includes success after a red build — also worth hearing).
+  if (prev.ci_status !== curr.ci_status) {
+    return `CI ${curr.ci_status ?? "unknown"}`;
+  }
+
+  // Review-state change for any reviewer. Prefer the first non-matching one
+  // to keep the output short; the full state lives in the app itself.
+  const prevByLogin = new Map(
+    prev.reviewers.map((r) => [r.login, r.state] as const),
+  );
+  for (const r of curr.reviewers) {
+    if (prevByLogin.get(r.login) !== r.state) {
+      return `${r.login} ${r.state.replace("_", " ")}`;
+    }
+  }
+
+  // Comment count went up — someone commented.
+  if (curr.comments > prev.comments) {
+    const delta = curr.comments - prev.comments;
+    return `+${delta} comment${delta === 1 ? "" : "s"}`;
+  }
+
+  // Nothing above matched but updated_at moved — some edit happened we don't
+  // model (labels, assignees, etc). Worth a quiet catch-all notification so
+  // the user knows something changed upstream.
+  if (prev.updated_at !== curr.updated_at) {
+    return "Updated";
+  }
+
+  return null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import { onDestroy, onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import {
+    computeItemChanges,
     filterVisible,
     groupByRepo,
     itemKey,
@@ -70,6 +71,7 @@
   let newWatchedOrg = $state("");
 
   let prevThreads = new Map<number, string>();
+  let prevItems = new Map<number, WatchedItem>();
   let hasLoadedOnce = false;
   let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -207,21 +209,41 @@
         const fresh = fetchedNotifs.filter(
           (n) => prevThreads.get(n.thread_id) !== n.updated_at,
         );
+
+        // Item-level diff: catches changes GitHub doesn't generate a
+        // notification thread for (another reviewer approved, CI status
+        // flipped, PR merged upstream, etc.). Anything already covered by
+        // the /notifications fresh set is dropped to avoid double-firing.
+        const notifiedKeys = new Set(
+          fresh
+            .filter((n) => n.number != null)
+            .map((n) => `${n.repo}:${n.kind}:${n.number}`),
+        );
+        const itemChanges = computeItemChanges(
+          prevItems,
+          fetchedItems,
+          notifiedKeys,
+        );
+
         console.info(
-          `[eir] refresh: ${fetchedNotifs.length} unread notifications, ${fresh.length} new or updated since last fetch`,
+          `[eir] refresh: ${fetchedNotifs.length} unread notifications (${fresh.length} new), ${itemChanges.length} item-level changes`,
         );
         if (fresh.length > 0) {
           await notify(fresh);
         }
+        if (itemChanges.length > 0) {
+          await notifyItemChanges(itemChanges);
+        }
       } else {
         console.info(
-          `[eir] initial load: ${fetchedNotifs.length} unread notifications (suppressed)`,
+          `[eir] initial load: ${fetchedNotifs.length} unread notifications, ${fetchedItems.length} items (notifications suppressed)`,
         );
       }
 
       items = fetchedItems;
       notifications = fetchedNotifs;
       prevThreads = nextThreads;
+      prevItems = new Map(fetchedItems.map((i) => [i.id, i]));
       hasLoadedOnce = true;
       phase = "loaded";
       updateBadge();
@@ -243,6 +265,7 @@
     items = [];
     notifications = [];
     prevThreads = new Map();
+    prevItems = new Map();
     hasLoadedOnce = false;
     phase = "idle";
     void invoke("set_tray_badge", { count: 0 });
@@ -268,6 +291,22 @@
         return "CI update";
       default:
         return "New activity";
+    }
+  }
+
+  async function notifyItemChanges(
+    changes: { item: WatchedItem; reason: string }[],
+  ) {
+    if (!notifyEnabled) return;
+    if (!(await ensureNotificationPermission())) return;
+    for (const { item, reason } of changes) {
+      console.info(
+        `[eir] sending item-change notification: ${reason} — ${item.repo}#${item.number}`,
+      );
+      sendNotification({
+        title: reason,
+        body: `${item.repo}#${item.number} — ${item.title}`,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a second notification channel: the **item-list diff**.

Previously, desktop notifications fired only when a new unread notification thread showed up in \`/notifications\`. That misses things GitHub doesn't thread for you:
- Someone else approves / requests changes on a PR where you're only a reviewer
- CI flips red
- A draft is marked ready
- A PR gets merged upstream
- Labels / assignees change

The refresh cycle now also diffs the \`items\` list from the previous fetch and fires a notification per meaningful change. Dedup against the \`/notifications\` fresh set keeps to one notification per underlying event.

### Signal ranking
\`describeItemChange\` ranks signals by actionability (CI failure > label tweak):
1. State change (\`Now merged\` / \`Now closed\`)
2. Draft ⇄ ready
3. CI status change
4. Reviewer state change (by first mismatched reviewer)
5. Comment count growth
6. \`updated_at\` fallback (\"Updated\")

### Dedup
If a change already has a \`/notifications\` entry this tick (matched by \`(repo, kind, number)\`), skip it on the item-diff side.

### Tests
| Surface | Before | After |
|---|---|---|
| Rust (\`cargo test --lib\`) | 23 | **29** |
| Frontend (\`pnpm test\`) | 11 | **25** |

- \`describeItemChange\`: 8 cases covering every branch + null
- \`computeItemChanges\`: 6 cases (empty / new / changed / notified-skip / notified-skip-new / combined)
- \`merge_search_results\` (Rust, newly extracted): 6 cases (sort, alias dedup, PR+Issue mix, Unknown skip, None-slot skip)
- \`issue_to_item\`: dedicated scalar-field test

## Test plan

- [ ] \`cd src-tauri && cargo test --lib\` green
- [ ] \`pnpm test\` green
- [ ] \`pnpm tauri dev\`, change a PR's state on GitHub (merge, close, or flip draft) and confirm the popup fires a desktop notification
- [ ] Confirm no double-fire when the same PR also appears in the GitHub notifications inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)