### PR TITLE
fix: pre-v0.1.0 release bundle fixes (svelte-kit sync + ad-hoc codesign)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "svelte-kit sync && vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   }
 }


### PR DESCRIPTION
Two fixes surfaced while cutting the v0.1.0 release. Bundling because both touch the release pipeline.

## 1. \`pnpm build\` now runs \`svelte-kit sync\` first

\`vite build\` references \`./.svelte-kit/tsconfig.json\` via the root \`tsconfig.json\`, but that file is generated by \`svelte-kit sync\`. A fresh clone (including the CI environment) has never run sync before build, so vite logs:

\`\`\`
Cannot find base config file "./.svelte-kit/tsconfig.json"
\`\`\`

The warning is benign (vite falls back to the parent config), but it's noise in every release build. Prefix \`svelte-kit sync\` to the build script — same pattern \`pnpm check\` already uses.

## 2. Ad-hoc codesign macOS bundles

Users opening the v0.1.0 \`.dmg\` hit:

> \"eir.app\" is damaged and can't be opened. You should move it to the Trash.

macOS's quarantine attribute on downloaded Mach-O binaries means Gatekeeper rejects any unsigned app with a generic "damaged" error on recent macOS versions. Adding \`bundle.macOS.signingIdentity: \"-\"\` to \`tauri.conf.json\` tells Tauri to apply **ad-hoc codesigning** during \`tauri build\`.

Ad-hoc signing isn't a real Developer ID — users still see the first-run Gatekeeper warning and need right-click → Open once — but it prevents the hard "damaged" rejection. Same fix [Lecto-inc/lecto-csv-import-app landed for the same symptom](https://github.com/Lecto-inc/lecto-csv-import-app/commit/cd3ca8c5a1a31cd8d0c53cbbd998c821d778f7f6).

Future: swap \`\"-\"\` for an Apple Developer Team ID + notarization secrets when available.

## Test plan

- [ ] Delete the broken v0.1.0 draft release + tag
- [ ] Merge this PR
- [ ] Re-tag v0.1.0 on the new HEAD
- [ ] Release workflow rebuilds bundles; confirm \`pnpm build\` warning is gone
- [ ] Download the .dmg, drag eir.app to /Applications, right-click → Open; app launches without "damaged"