### PR TITLE
feat: in-app Check for Updates (Tauri updater)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,19 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Ad-hoc signing only; adding an Apple Developer ID later will
-          # populate APPLE_CERTIFICATE / APPLE_SIGNING_IDENTITY and enable
-          # real signing + notarization without changing the workflow.
+          # Signs the updater artefacts (.app.tar.gz + latest.json) with
+          # the ed25519 keypair whose public half lives in tauri.conf.json.
+          # Without this secret, tauri-action skips updater signing and
+          # the in-app "Check for updates" flow won't verify the download.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Ad-hoc macOS codesign only; adding an Apple Developer ID later
+          # will populate APPLE_CERTIFICATE / APPLE_SIGNING_IDENTITY and
+          # enable real signing + notarization without changing the workflow.
         with:
           tagName: ${{ steps.tag.outputs.name }}
           releaseName: eir ${{ steps.tag.outputs.name }}
           releaseDraft: true
           prerelease: false
+          includeUpdaterJson: true
           args: --target ${{ matrix.target }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.6
@@ -550,6 +556,12 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
@@ -1364,6 +1376,14 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +826,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1052,8 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tokio",
 ]
 
@@ -1196,6 +1218,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2398,7 +2431,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2514,6 +2550,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2794,6 +2836,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,6 +2968,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,7 +3054,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3272,6 +3340,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3665,6 +3739,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4414,7 +4497,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4646,6 +4729,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4837,6 +4931,49 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -6427,6 +6564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6594,6 +6741,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,6 @@ tokio = { version = "1.52.1", features = ["rt", "time"] }
 tauri-plugin-notification = "2.3.3"
 rustls = { version = "0.23.38", default-features = false, features = ["aws-lc-rs"] }
 tauri-plugin-global-shortcut = "2.3.1"
+tauri-plugin-updater = "2.10.1"
+tauri-plugin-process = "2.3.1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "notification:default"
+    "notification:default",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,8 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(|app, _shortcut, event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,8 +39,17 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "createUpdaterArtifacts": true,
     "macOS": {
       "signingIdentity": "-"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/yagince/eir/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDlBQzkxQkIyRTRBQkJCQjcKUldTM3U2dmtzaHZKbW1jRmllWUVNZkVRSmZLa2Vmc2I5K1BSWkNTQWR1QVljUk9odmI1dlA0UEkK"
     }
   }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,8 @@
     requestPermission,
     sendNotification,
   } from "@tauri-apps/plugin-notification";
+  import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
+  import { relaunch } from "@tauri-apps/plugin-process";
   import { onDestroy, onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import {
@@ -64,6 +66,16 @@
   let capturingShortcut = $state(false);
   let shortcutError = $state<string | null>(null);
   let selectedId = $state<number | null>(null);
+
+  type UpdateStatus =
+    | { kind: "idle" }
+    | { kind: "checking" }
+    | { kind: "up-to-date" }
+    | { kind: "available"; version: string }
+    | { kind: "downloading" }
+    | { kind: "installed" }
+    | { kind: "error"; message: string };
+  let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   const excludedRepos = new SvelteSet<string>(loadExcludedRepos());
   const hiddenItems = new SvelteSet<number>(loadHiddenItems());
   const watchedOrgs = new SvelteSet<string>(loadWatchedOrgs());
@@ -333,6 +345,37 @@
     }
   }
 
+  async function runUpdateCheck(opts: { interactive: boolean }) {
+    if (updateStatus.kind === "checking" || updateStatus.kind === "downloading")
+      return;
+    updateStatus = { kind: "checking" };
+    try {
+      const update = await checkForUpdate();
+      if (!update) {
+        updateStatus = { kind: "up-to-date" };
+        console.info("[eir] update check: already latest");
+        return;
+      }
+      console.info(
+        `[eir] update check: ${update.version} available (current ${update.currentVersion})`,
+      );
+      updateStatus = { kind: "available", version: update.version };
+      if (!opts.interactive) {
+        // Silent check on boot — just record availability, let the user
+        // click the Settings button when they're ready. No auto-install.
+        return;
+      }
+      updateStatus = { kind: "downloading" };
+      await update.downloadAndInstall();
+      updateStatus = { kind: "installed" };
+      await relaunch();
+    } catch (e) {
+      const message = String(e);
+      console.warn("[eir] update check failed:", message);
+      updateStatus = { kind: "error", message };
+    }
+  }
+
   async function sendTestNotification() {
     if (!(await ensureNotificationPermission())) {
       error =
@@ -366,6 +409,9 @@
     }
     window.addEventListener("keydown", handleGlobalKey);
     void loadItems({ silent: true });
+    // Silent update check on boot — if a new version is out, the Settings
+    // button will show "Update available" and the user can choose to install.
+    void runUpdateCheck({ interactive: false });
   });
 
   onDestroy(() => {
@@ -711,6 +757,41 @@
         <div class="setting-row">
           <span class="setting-label">Test notification</span>
           <button class="secondary" onclick={sendTestNotification}>Send</button>
+        </div>
+
+        <div class="setting-row">
+          <span class="setting-label">
+            Check for updates
+            {#if updateStatus.kind === "up-to-date"}
+              <span class="setting-hint-inline">— already latest</span>
+            {:else if updateStatus.kind === "available"}
+              <span class="setting-hint-inline update-available"
+                >— v{updateStatus.version} available</span
+              >
+            {:else if updateStatus.kind === "installed"}
+              <span class="setting-hint-inline">— installed, relaunching…</span>
+            {:else if updateStatus.kind === "error"}
+              <span class="setting-hint-inline error-inline"
+                >— {updateStatus.message}</span
+              >
+            {/if}
+          </span>
+          <button
+            class="secondary"
+            disabled={updateStatus.kind === "checking" ||
+              updateStatus.kind === "downloading"}
+            onclick={() => runUpdateCheck({ interactive: true })}
+          >
+            {#if updateStatus.kind === "checking"}
+              Checking…
+            {:else if updateStatus.kind === "downloading"}
+              Installing…
+            {:else if updateStatus.kind === "available"}
+              Install v{updateStatus.version}
+            {:else}
+              Check
+            {/if}
+          </button>
         </div>
         <div class="setting-row">
           <span class="setting-label">Toggle popup shortcut</span>
@@ -1121,6 +1202,21 @@
     background: rgba(9, 105, 218, 0.15);
     border-color: #0969da;
     color: #0969da;
+  }
+
+  .setting-hint-inline {
+    font-size: 11px;
+    color: rgba(27, 27, 31, 0.55);
+    margin-left: 4px;
+  }
+
+  .setting-hint-inline.update-available {
+    color: #1a7f37;
+    font-weight: 500;
+  }
+
+  .setting-hint-inline.error-inline {
+    color: #d1242f;
   }
 
   .setting-section {
@@ -1644,8 +1740,15 @@
     .signout,
     .group-header,
     .back,
-    .setting-hint {
+    .setting-hint,
+    .setting-hint-inline {
       color: rgba(236, 236, 239, 0.6);
+    }
+    .setting-hint-inline.update-available {
+      color: #3fb950;
+    }
+    .setting-hint-inline.error-inline {
+      color: #ff7b72;
     }
     .group-header {
       background: rgba(30, 30, 32, 0.98);


### PR DESCRIPTION
Adds the Tauri updater end-to-end so future releases can be picked up by the app itself.

## Flow
1. **Silent check on boot** — after items load, the app calls \`check()\` once. If a newer release is available, Settings shows "v0.2.0 available" in green; no download happens without user action.
2. **Interactive install** — user clicks the **Install v0.2.0** button in Settings → download + verify signature + replace the app + \`relaunch()\`.
3. **Errors** — anything that fails (network, bad signature, etc.) surfaces inline in red.

## Moving parts

| Layer | Change |
|---|---|
| Rust | \`tauri-plugin-updater\` + \`tauri-plugin-process\` added to \`Cargo.toml\` and registered in \`lib.rs\` |
| Config | \`tauri.conf.json\` → \`plugins.updater\` with endpoint + public key, \`bundle.createUpdaterArtifacts: true\` |
| Capabilities | \`updater:default\`, \`process:default\` |
| Frontend | \`runUpdateCheck({ interactive })\` in \`+page.svelte\`, new Settings row with state-aware label |
| CI | \`release.yml\` picks up \`TAURI_SIGNING_PRIVATE_KEY\` / \`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\` secrets + \`includeUpdaterJson: true\` so each release ships \`latest.json\` + signed \`.app.tar.gz\` |

## User setup (one-time)

Done already:
- [x] Generated ed25519 keypair with \`pnpm tauri signer generate\`
- [x] Public key embedded in \`tauri.conf.json\`
- [x] Private key + password registered as GitHub secrets

## Notes
- Updater endpoint points at \`releases/latest/download/latest.json\`, so cutting a new tag is the only step for future releases — tauri-action writes the manifest as part of the release.
- Apple Developer ID signing is still a future step; the updater signature is independent and already works.

## Test plan

- [ ] Merge
- [ ] Cut a test v0.1.1 release, confirm \`latest.json\` shows up in the release assets
- [ ] Install v0.1.0 locally, open, check Settings → "v0.1.1 available" appears on next boot
- [ ] Click Install v0.1.1, confirm download + relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)