### PR TITLE
feat: cross-platform support for Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,24 @@ jobs:
         run: pnpm test
 
   rust:
-    name: rust (fmt + clippy + test)
-    runs-on: macos-latest
+    # Compile on every supported platform so the cfg branches for Windows and
+    # Linux don't rot unnoticed. fmt/clippy/tests only run once (on macOS) to
+    # avoid paying for the same lint work on all three runners.
+    name: rust (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            label: macos
+            full_checks: true
+          - os: ubuntu-22.04
+            label: linux
+            full_checks: false
+          - os: windows-latest
+            label: windows
+            full_checks: false
     defaults:
       run:
         working-directory: src-tauri
@@ -49,12 +65,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          key: ${{ matrix.label }}
+
+      - name: Install Linux system deps
+        if: matrix.os == 'ubuntu-22.04'
+        working-directory: ${{ github.workspace }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
 
       - name: fmt
+        if: matrix.full_checks
         run: cargo fmt --all -- --check
 
       - name: clippy
+        if: matrix.full_checks
         run: cargo clippy --all-targets -- -D warnings
 
       - name: test
+        if: matrix.full_checks
         run: cargo test --lib
+
+      - name: check (platform compile)
+        if: ${{ !matrix.full_checks }}
+        run: cargo check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,24 @@ on:
 
 jobs:
   build:
-    name: build (${{ matrix.target }})
-    runs-on: macos-latest
+    name: build (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-apple-darwin
-            arch: arm64
-          - target: x86_64-apple-darwin
-            arch: x64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            label: macos-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            label: macos-x64
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            label: linux-x64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            label: windows-x64
     steps:
       - uses: actions/checkout@v6
 
@@ -43,10 +51,32 @@ jobs:
           workspaces: src-tauri
           key: ${{ matrix.target }}
 
+      # Tauri on Linux pulls in WebKitGTK, AppIndicator, and librsvg through
+      # the system package manager. These aren't preinstalled on the GitHub
+      # runner image, so the build fails at the WebView link step without
+      # them. WebView2 on Windows and WKWebView on macOS are system-provided,
+      # so only Linux needs this step.
+      - name: Install Linux system deps
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
       - run: pnpm install --frozen-lockfile
 
       - name: Resolve tag
         id: tag
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
@@ -58,10 +88,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Signs the updater artefacts (.app.tar.gz + latest.json) with
-          # the ed25519 keypair whose public half lives in tauri.conf.json.
-          # Without this secret, tauri-action skips updater signing and
-          # the in-app "Check for updates" flow won't verify the download.
+          # Signs the updater artefacts (.app.tar.gz / .nsis.zip / .AppImage
+          # .tar.gz + latest.json) with the ed25519 keypair whose public half
+          # lives in tauri.conf.json. Without this secret, tauri-action skips
+          # updater signing and the in-app "Check for updates" flow won't
+          # verify the download.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # Ad-hoc macOS codesign only; adding an Apple Developer ID later

--- a/README.md
+++ b/README.md
@@ -1,43 +1,62 @@
 # eir
 
-A macOS menubar app that watches GitHub PRs and Issues — a from-scratch alternative to Trailer / Neat, built with Tauri v2 and SvelteKit.
+A menubar app that watches GitHub PRs and Issues — a from-scratch alternative to Trailer / Neat, built with Tauri v2 and SvelteKit. Runs on macOS, Windows, and Linux.
 
 Named after Eir, the Norse goddess of healing. The icon combines a watching eye with a feather.
 
 ## Features
 
-- **Menubar only** — no dock icon; the app lives as a tray icon with a 380×520 popup
-- **GitHub OAuth device flow** — sign in once, the token is stored in a mode-0600 file at `~/.config/eir/token` and survives restarts
+- **Menubar / system-tray only** — no taskbar entry; lives as a tray icon with a 380×520 popup (auto-expands to fill screen height on macOS)
+- **GitHub OAuth device flow** — sign in once, the token is stored in a per-user config file and survives restarts
 - **Grouped list** — PRs and Issues grouped by repository with sticky headers and per-repo unread counts
 - **Filter tabs** — All / Mine / Review Requests / Mentions, backed by different GitHub search queries
 - **Auto-refresh** — silent background polling every 30s–5min (configurable)
 - **Native notifications** — desktop notifications when a new PR or Issue first appears
-- **Unread tracking** — tray badge shows total unread count; clicking an item marks it read
+- **Unread tracking** — macOS tray badge shows the unread count; Windows/Linux show it in the hover tooltip
 - **Global shortcut** — `Ctrl+Shift+E` toggles the popup from anywhere
-- **Light/dark aware** — template-mode tray icon and `prefers-color-scheme` styling follow the system
+- **Light/dark aware** — template-mode tray icon on macOS and `prefers-color-scheme` styling everywhere
 
 ## Install
 
-Download the latest `.dmg` for your Mac from the [Releases page](https://github.com/yagince/eir/releases/latest):
+Grab the latest build for your OS from the [Releases page](https://github.com/yagince/eir/releases/latest).
+
+### macOS
 
 - Apple Silicon (M1/M2/M3/M4): `eir_<version>_aarch64.dmg`
 - Intel: `eir_<version>_x64.dmg`
 
-Open the DMG and drag **eir.app** into `/Applications`.
-
-### First launch on macOS
-
-The bundle is ad-hoc signed (no Apple Developer ID yet), so Gatekeeper will refuse to open it on the first try with a `"eir.app" is damaged and can't be opened` message. Remove the quarantine attribute once:
+Open the DMG and drag **eir.app** into `/Applications`. The bundle is ad-hoc signed (no Apple Developer ID yet), so on first launch Gatekeeper refuses with `"eir.app" is damaged and can't be opened`. Remove the quarantine attribute once:
 
 ```bash
 xattr -rd com.apple.quarantine /Applications/eir.app
 ```
 
-Then launch it normally. Subsequent launches (including after auto-update) don't need this step.
+Then launch it normally. Subsequent launches — including after the in-app updater swaps the binary — don't need this step.
 
-### Updates
+### Windows
 
-From v0.1.1 onward, eir ships with an in-app updater. Open the popup → gear icon → **Check for updates**. When a newer version is published, it downloads the signed bundle, verifies the ed25519 signature, and relaunches into the new version.
+Download `eir_<version>_x64-setup.exe` (or `.msi`) and run it. On the SmartScreen "Windows protected your PC" dialog, click **More info → Run anyway** — the build isn't signed with a code-signing certificate yet. Token is stored at `%APPDATA%\eir\token`.
+
+### Linux
+
+Download `eir_<version>_amd64.AppImage` and make it executable:
+
+```bash
+chmod +x eir_<version>_amd64.AppImage
+./eir_<version>_amd64.AppImage
+```
+
+Or install the `.deb` on Debian / Ubuntu derivatives:
+
+```bash
+sudo apt install ./eir_<version>_amd64.deb
+```
+
+A system tray is required. On GNOME, install the [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension if you don't already have one.
+
+## Updates
+
+eir ships with an in-app updater. Open the popup → gear icon → **Check for updates**. When a newer version is published, it downloads the signed bundle, verifies the ed25519 signature, and relaunches into the new version.
 
 ## Development
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,11 +1,30 @@
-// Fetch the latest release metadata and rewrite the CTA buttons to point at the
-// exact .dmg assets, so visitors get the binary in one click instead of landing
-// on the releases page and scanning for the right file. Falls back silently to
-// the generic /releases/latest link if the API is rate-limited or unreachable.
+// Fetch the latest release metadata and rewrite the CTA buttons to point at
+// the exact per-platform assets, so visitors get the binary in one click
+// instead of landing on the releases page and scanning for the right file.
+// Falls back silently to the generic /releases/latest link if the API is
+// rate-limited or unreachable.
 (async function updateDownloadLinks() {
   const versionEl = document.getElementById("version-line");
-  const arm64Btn = document.getElementById("download-arm64");
-  const intelBtn = document.getElementById("download-intel");
+
+  // Each entry: [button id, predicate matching the asset filename]. Order the
+  // checks from most specific to least so macOS arm64 isn't mis-matched as
+  // "generic mac" etc.
+  const matchers = [
+    ["download-arm64", (n) => /aarch64/i.test(n) && n.endsWith(".dmg")],
+    [
+      "download-intel",
+      (n) => /(x64|x86_64)/i.test(n) && n.endsWith(".dmg"),
+    ],
+    [
+      "download-windows",
+      (n) => /windows|\.msi$|setup\.exe$/i.test(n) && !n.endsWith(".sig"),
+    ],
+    [
+      "download-linux",
+      (n) =>
+        (/\.AppImage$/i.test(n) || /\.deb$/i.test(n)) && !n.endsWith(".sig"),
+    ],
+  ];
 
   try {
     const res = await fetch(
@@ -16,15 +35,12 @@
     const release = await res.json();
 
     const assets = release.assets || [];
-    const arm64 = assets.find(
-      (a) => /aarch64/i.test(a.name) && a.name.endsWith(".dmg"),
-    );
-    const intel = assets.find(
-      (a) => /x64|x86_64/i.test(a.name) && a.name.endsWith(".dmg"),
-    );
-
-    if (arm64) arm64Btn.href = arm64.browser_download_url;
-    if (intel) intelBtn.href = intel.browser_download_url;
+    for (const [id, predicate] of matchers) {
+      const btn = document.getElementById(id);
+      if (!btn) continue;
+      const asset = assets.find((a) => predicate(a.name));
+      if (asset) btn.href = asset.browser_download_url;
+    }
 
     versionEl.textContent = "Latest release: " + release.tag_name;
   } catch (err) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,12 +6,12 @@
     <title>eir — a menubar watcher for GitHub PRs & Issues</title>
     <meta
       name="description"
-      content="eir is a macOS menubar app that watches GitHub PRs and Issues. A from-scratch alternative to Trailer / Neat, built with Tauri and SvelteKit."
+      content="eir is a cross-platform menubar app that watches GitHub PRs and Issues. A from-scratch alternative to Trailer / Neat, built with Tauri and SvelteKit."
     />
     <meta property="og:title" content="eir — menubar GitHub PR/Issue watcher" />
     <meta
       property="og:description"
-      content="A macOS menubar app that watches GitHub PRs and Issues. Built with Tauri v2 + SvelteKit."
+      content="A menubar app that watches GitHub PRs and Issues on macOS, Windows, and Linux. Built with Tauri v2 + SvelteKit."
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="assets/screenshot.png" />
@@ -25,8 +25,8 @@
         <img class="logo" src="assets/icon-256.png" alt="eir icon" width="128" height="128" />
         <h1>eir</h1>
         <p class="tagline">
-          A macOS menubar app that watches GitHub PRs and Issues.<br />
-          A from-scratch alternative to Trailer / Neat.
+          A menubar / system-tray app that watches GitHub PRs and Issues.<br />
+          A from-scratch alternative to Trailer / Neat — macOS, Windows, Linux.
         </p>
 
         <div class="cta">
@@ -42,7 +42,21 @@
             class="btn secondary"
             href="https://github.com/yagince/eir/releases/latest"
           >
-            Download for Intel
+            Download for Intel Mac
+          </a>
+          <a
+            id="download-windows"
+            class="btn secondary"
+            href="https://github.com/yagince/eir/releases/latest"
+          >
+            Download for Windows
+          </a>
+          <a
+            id="download-linux"
+            class="btn secondary"
+            href="https://github.com/yagince/eir/releases/latest"
+          >
+            Download for Linux
           </a>
         </div>
         <p id="version-line" class="version">Latest release: loading…</p>
@@ -67,12 +81,15 @@
         <h2>Features</h2>
         <ul class="feature-grid">
           <li>
-            <h3>Menubar only</h3>
-            <p>No dock icon. Lives as a tray icon with a compact 380×520 popup.</p>
+            <h3>Tray only</h3>
+            <p>
+              No taskbar entry. Lives as a tray icon with a compact 380×520 popup (auto-expands
+              to fill screen height on macOS).
+            </p>
           </li>
           <li>
             <h3>GitHub OAuth device flow</h3>
-            <p>Sign in once — the token persists across restarts in a mode-0600 file.</p>
+            <p>Sign in once — the token persists across restarts in a per-user config file.</p>
           </li>
           <li>
             <h3>Grouped by repository</h3>
@@ -92,7 +109,10 @@
           </li>
           <li>
             <h3>Unread tracking</h3>
-            <p>Tray badge shows unread count. Clicking an item marks it read.</p>
+            <p>
+              macOS shows the count right on the menubar icon. Windows / Linux surface it
+              through the tray tooltip.
+            </p>
           </li>
           <li>
             <h3>Global shortcut</h3>
@@ -104,8 +124,8 @@
           <li>
             <h3>Light / dark aware</h3>
             <p>
-              Template-mode tray icon and <code>prefers-color-scheme</code> styling follow the
-              system.
+              Template-mode tray icon on macOS and <code>prefers-color-scheme</code> styling
+              everywhere.
             </p>
           </li>
           <li>
@@ -120,27 +140,61 @@
 
       <section class="install">
         <h2>Install</h2>
+
+        <h3>macOS</h3>
         <ol>
-          <li>
-            Download the <code>.dmg</code> for your architecture above — or grab it from the
-            <a href="https://github.com/yagince/eir/releases/latest" target="_blank" rel="noopener"
-              >Releases page</a
-            >.
-          </li>
+          <li>Download the <code>.dmg</code> for your architecture above.</li>
           <li>Open the DMG and drag <strong>eir.app</strong> into <code>/Applications</code>.</li>
           <li>
             Remove the quarantine attribute so Gatekeeper lets it launch (the bundle is ad-hoc
             signed — no Apple Developer ID yet):
             <pre><code id="xattr-cmd">xattr -rd com.apple.quarantine /Applications/eir.app</code><button class="copy-btn" data-copy-target="xattr-cmd" aria-label="Copy command">Copy</button></pre>
           </li>
-          <li>
-            Launch eir. Click the feather-and-eye icon in the menubar → sign in with GitHub device
-            flow. You're done.
-          </li>
+          <li>Launch eir and sign in with the GitHub device flow.</li>
         </ol>
         <p class="note">
           Subsequent launches — including after the in-app updater swaps the binary — don't need
           the <code>xattr</code> step again.
+        </p>
+
+        <h3>Windows</h3>
+        <ol>
+          <li>
+            Download <code>eir_&lt;version&gt;_x64-setup.exe</code> (or the <code>.msi</code>)
+            and run it.
+          </li>
+          <li>
+            On the SmartScreen <em>"Windows protected your PC"</em> dialog, click
+            <strong>More info → Run anyway</strong>. The build isn't code-signed with an
+            Authenticode certificate yet.
+          </li>
+          <li>Launch eir from the Start menu and sign in.</li>
+        </ol>
+        <p class="note">
+          Token is stored at <code>%APPDATA%\eir\token</code>. A system tray is required — all
+          stock Windows 10/11 installs have one.
+        </p>
+
+        <h3>Linux</h3>
+        <ol>
+          <li>
+            Download <code>eir_&lt;version&gt;_amd64.AppImage</code> and make it executable:
+            <pre><code id="linux-appimage-cmd">chmod +x eir_*_amd64.AppImage &amp;&amp; ./eir_*_amd64.AppImage</code><button class="copy-btn" data-copy-target="linux-appimage-cmd" aria-label="Copy command">Copy</button></pre>
+          </li>
+          <li>
+            Or install the <code>.deb</code> on Debian / Ubuntu derivatives:
+            <pre><code id="linux-deb-cmd">sudo apt install ./eir_*_amd64.deb</code><button class="copy-btn" data-copy-target="linux-deb-cmd" aria-label="Copy command">Copy</button></pre>
+          </li>
+        </ol>
+        <p class="note">
+          A system tray is required. On GNOME, install the
+          <a
+            href="https://extensions.gnome.org/extension/615/appindicator-support/"
+            target="_blank"
+            rel="noopener"
+            >AppIndicator Support</a
+          >
+          extension if you don't already have one.
         </p>
       </section>
 

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -15,23 +15,39 @@ fn http() -> &'static reqwest::Client {
     HTTP.get_or_init(reqwest::Client::new)
 }
 
-/// Plain file under `$HOME/.config/eir/token` with mode 0600.
+/// Plain file under a per-user config directory, mode 0600 on unix.
+///
+/// - macOS / Linux: `$HOME/.config/eir/token`
+/// - Windows: `%APPDATA%\eir\token`
 ///
 /// We deliberately don't use the OS keychain. macOS Keychain ACLs bind to the
 /// caller's cdhash, which changes on every rebuild / new release — so
 /// "Always Allow" re-prompts the user on every update unless the app is
 /// signed with a stable Apple Developer ID *and* the ACL is set up with a
 /// Designated Requirement (which the `keyring` crate does not do). A
-/// mode-0600 file behaves consistently across dev and release builds, and
-/// matches what tools like `gh`, `git-credential-store`, and the `cargo`
-/// registry credentials file do.
+/// plain mode-0600 file behaves consistently across dev and release builds,
+/// and matches what tools like `gh`, `git-credential-store`, and the `cargo`
+/// registry credentials file do. Windows stores the file under `%APPDATA%`
+/// where per-user ACLs already restrict access to the owning account.
 mod token_store {
     use std::io::Write;
     use std::path::PathBuf;
 
+    #[cfg(not(windows))]
     fn path() -> Option<PathBuf> {
         let home = std::env::var_os("HOME")?;
-        Some(PathBuf::from(home).join(".config/eir/token"))
+        Some(
+            PathBuf::from(home)
+                .join(".config")
+                .join("eir")
+                .join("token"),
+        )
+    }
+
+    #[cfg(windows)]
+    fn path() -> Option<PathBuf> {
+        let appdata = std::env::var_os("APPDATA")?;
+        Some(PathBuf::from(appdata).join("eir").join("token"))
     }
 
     pub fn load() -> Option<String> {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,12 +5,26 @@ use tauri::{
     App, Manager, PhysicalPosition,
 };
 
+// macOS uses a template-mode monochrome icon so the system can tint it based
+// on menubar state (dark/light/focus). Windows and Linux taskbars don't
+// support template mode — they expect a normal colored icon. Shipping two
+// assets and picking at build time keeps the tray recognizable on each OS.
+#[cfg(target_os = "macos")]
 const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/tray-icon.png");
+#[cfg(not(target_os = "macos"))]
+const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/32x32.png");
+
 const TRAY_ID: &str = "main";
 
 #[tauri::command]
 pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
-    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+
+    // macOS menubar: adjacent text next to the icon.
+    #[cfg(target_os = "macos")]
+    {
         let title = if count == 0 {
             None
         } else if has_unread {
@@ -24,10 +38,24 @@ pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
         eprintln!("[eir] set_tray_badge count={count} has_unread={has_unread} title={title:?}");
         let _ = tray.set_title(title);
     }
+
+    // Windows / Linux: no adjacent-text slot on the tray icon, so surface the
+    // count + unread state through the hover tooltip instead.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let tooltip = if count == 0 {
+            "eir".to_string()
+        } else if has_unread {
+            format!("eir — {count} (unread)")
+        } else {
+            format!("eir — {count}")
+        };
+        let _ = tray.set_tooltip(Some(&tooltip));
+    }
 }
 
 /// Toggle the popup window. If visible, hide it. If hidden, position it
-/// under the tray icon (centered) and show it.
+/// near the tray icon and show it.
 pub fn toggle_popup(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
@@ -36,12 +64,12 @@ pub fn toggle_popup(app: &tauri::AppHandle) {
         let _ = window.hide();
         return;
     }
-    position_under_tray(app, &window);
+    position_near_tray(app, &window);
     let _ = window.show();
     let _ = window.set_focus();
 }
 
-fn position_under_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
+fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
     let Some(tray) = app.tray_by_id(TRAY_ID) else {
         return;
     };
@@ -59,26 +87,72 @@ fn position_under_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
         _ => return,
     };
 
-    let popup_top = tray_y + tray_h + 8;
     let win_size = window.outer_size().unwrap_or_default();
     let popup_width = win_size.width as i32;
+    let popup_height = win_size.height as i32;
 
-    // Grow the popup to fill as much vertical screen space as possible,
-    // leaving room for the Dock.
-    if let Ok(Some(monitor)) = window.current_monitor() {
-        let m_pos = monitor.position();
-        let m_size = monitor.size();
-        let bottom = m_pos.y + m_size.height as i32;
-        let dock_margin = (80.0 * monitor.scale_factor()) as i32;
-        let target_height = (bottom - popup_top - dock_margin).max(400);
-        let _ = window.set_size(tauri::PhysicalSize {
-            width: popup_width as u32,
-            height: target_height as u32,
-        });
-    }
+    let monitor = window.current_monitor().ok().flatten();
+    let (monitor_top, monitor_bottom, monitor_left, monitor_right) = match monitor.as_ref() {
+        Some(m) => {
+            let pos = m.position();
+            let size = m.size();
+            (
+                pos.y,
+                pos.y + size.height as i32,
+                pos.x,
+                pos.x + size.width as i32,
+            )
+        }
+        None => (0, i32::MAX, 0, i32::MAX),
+    };
+
+    // Decide above vs below: tray closer to the top of the monitor → drop the
+    // popup below it (macOS menubar). Tray closer to the bottom → raise the
+    // popup above it (Windows taskbar / KDE default).
+    let tray_center_y = tray_y + tray_h / 2;
+    let monitor_mid_y = monitor_top + (monitor_bottom - monitor_top) / 2;
+    let open_below = tray_center_y < monitor_mid_y;
+
+    // On macOS we take advantage of having the tray at the top to grow the
+    // popup to fill most of the screen height. On Windows/Linux the tray
+    // isn't consistently at one edge, so we stick with the configured size.
+    #[cfg(target_os = "macos")]
+    let popup_height = {
+        if let Some(m) = monitor.as_ref() {
+            let dock_margin = (80.0 * m.scale_factor()) as i32;
+            let bottom = monitor_top + m.size().height as i32;
+            let popup_top = tray_y + tray_h + 8;
+            let target_height = (bottom - popup_top - dock_margin).max(400);
+            let _ = window.set_size(tauri::PhysicalSize {
+                width: popup_width as u32,
+                height: target_height as u32,
+            });
+            target_height
+        } else {
+            popup_height
+        }
+    };
+
+    let popup_top = if open_below {
+        tray_y + tray_h + 8
+    } else {
+        // Subtract the (possibly resized) height; fall back to tray_y - 8 if we
+        // can't determine a reasonable anchor.
+        (tray_y - popup_height - 8).max(monitor_top + 8)
+    };
 
     let tray_center_x = tray_x + tray_w / 2;
-    let x = tray_center_x - popup_width / 2;
+    let mut x = tray_center_x - popup_width / 2;
+    // Keep the window fully on the current monitor.
+    let max_x = monitor_right - popup_width - 8;
+    let min_x = monitor_left + 8;
+    if x > max_x {
+        x = max_x;
+    }
+    if x < min_x {
+        x = min_x;
+    }
+
     let _ = window.set_position(PhysicalPosition { x, y: popup_top });
 }
 
@@ -87,9 +161,14 @@ pub fn setup(app: &App) -> tauri::Result<()> {
     let menu = Menu::with_items(app, &[&quit_item])?;
 
     let tray_icon = Image::from_bytes(TRAY_ICON_BYTES)?;
-    TrayIconBuilder::with_id(TRAY_ID)
-        .icon(tray_icon)
-        .icon_as_template(true)
+    let builder = TrayIconBuilder::with_id(TRAY_ID).icon(tray_icon);
+
+    // Template mode is a macOS concept (NSImage tinting to match menubar
+    // appearance). Other platforms render the icon as-is.
+    #[cfg(target_os = "macos")]
+    let builder = builder.icon_as_template(true);
+
+    builder
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| {


### PR DESCRIPTION
## Summary

- Token storage now selects the platform-appropriate per-user config path: `$APPDATA\eir\token` on Windows, `~/.config/eir/token` elsewhere. `mode 0600` remains unix-only.
- Tray icon loads a color asset on Windows / Linux (`icons/32x32.png`) and keeps the template-mode monochrome one on macOS. `icon_as_template(true)` is now gated to macOS.
- `set_tray_badge` falls back to updating the tray **tooltip** on Windows / Linux, since the macOS menubar's adjacent text slot doesn't exist there.
- Popup positioning flips above the tray when it sits in the bottom half of the monitor (Windows taskbar, KDE default) and clamps horizontally to the current monitor. The macOS full-screen-height growth is preserved since the menubar is always at the top.
- Release workflow matrix extends to `ubuntu-22.04` (`.deb` / `.AppImage`) and `windows-latest` (`.msi` / `.exe`). Ubuntu step installs the required WebKitGTK / AppIndicator / librsvg system packages.
- CI's Rust job now compiles on all three platforms so the `#[cfg(...)]` branches don't rot. `fmt` / `clippy` / `test` stay on macOS only to avoid paying for the same lint pass 3×.
- README and the `docs/` landing page document each OS's install path (xattr on macOS, SmartScreen on Windows, AppIndicator extension on GNOME). The Pages CTAs auto-rewrite to Windows / Linux assets via the GitHub API.

## Test plan

- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] `cd src-tauri && cargo fmt --all -- --check`
- [x] `cd src-tauri && cargo test --lib` (29 tests passing)
- [x] `pnpm check` (0 errors)
- [x] `pnpm test` (25 tests passing)
- [ ] CI: Rust job green on all 3 platforms
- [ ] CI: Frontend lint + tests green
- [ ] Manual (after merge + tag): release build produces macOS `.dmg`, Linux `.AppImage` / `.deb`, Windows `.msi` / setup `.exe`
- [ ] Manual (after release): `latest.json` contains entries for all four target platforms so the in-app updater reaches Windows / Linux clients too