### PR TITLE
feat: show commenters on Issue rows

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -39,6 +39,13 @@ pub struct Reviewer {
     state: &'static str, // "approved" | "changes_requested" | "commented" | "dismissed" | "pending"
 }
 
+#[derive(Serialize, Clone)]
+#[cfg_attr(test, derive(Debug))]
+pub struct Commenter {
+    login: String,
+    avatar_url: String,
+}
+
 #[derive(Serialize)]
 pub struct WatchedItem {
     id: u64,
@@ -54,6 +61,7 @@ pub struct WatchedItem {
     state: &'static str,
     is_draft: bool,
     reviewers: Vec<Reviewer>,
+    commenters: Vec<Commenter>,
     ci_status: Option<&'static str>, // "success" | "pending" | "failure" | "error"
 }
 
@@ -134,7 +142,16 @@ fragment IssueFields on Issue {
   url
   updatedAt
   state
-  comments { totalCount }
+  comments(last: 20) {
+    totalCount
+    nodes {
+      author {
+        login
+        ... on User { avatarUrl }
+        ... on Bot { avatarUrl }
+      }
+    }
+  }
   repository { nameWithOwner }
   author {
     login
@@ -214,7 +231,7 @@ struct IssueNode {
     url: String,
     updated_at: String,
     state: String,
-    comments: CountNode,
+    comments: IssueCommentsNode,
     repository: RepoNode,
     author: Option<AuthorNode>,
 }
@@ -223,6 +240,19 @@ struct IssueNode {
 #[serde(rename_all = "camelCase")]
 struct CountNode {
     total_count: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueCommentsNode {
+    total_count: u32,
+    #[serde(default)]
+    nodes: Vec<Option<IssueCommentNode>>,
+}
+
+#[derive(Deserialize)]
+struct IssueCommentNode {
+    author: Option<AuthorNode>,
 }
 
 #[derive(Deserialize)]
@@ -385,6 +415,7 @@ fn pr_to_item(pr: PrNode) -> WatchedItem {
         state: map_item_state(&pr.state),
         is_draft: pr.is_draft,
         reviewers,
+        commenters: Vec::new(),
         ci_status,
     }
 }
@@ -401,6 +432,24 @@ fn issue_to_item(issue: IssueNode) -> WatchedItem {
         .and_then(|a| a.avatar_url.clone())
         .unwrap_or_default();
 
+    // Dedupe commenters by login, preserving the order of their first
+    // appearance in the (last-N) comments slice. The issue author is kept
+    // in the list too — they often drive the discussion and showing only
+    // "others" would hide that. The frontend can decide whether to draw
+    // the author chip differently.
+    let mut seen_logins: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut commenters: Vec<Commenter> = Vec::new();
+    for c in issue.comments.nodes.into_iter().flatten() {
+        let Some(user) = c.author else { continue };
+        if !seen_logins.insert(user.login.clone()) {
+            continue;
+        }
+        commenters.push(Commenter {
+            login: user.login,
+            avatar_url: user.avatar_url.unwrap_or_default(),
+        });
+    }
+
     WatchedItem {
         id: issue.database_id,
         kind: "issue",
@@ -415,6 +464,7 @@ fn issue_to_item(issue: IssueNode) -> WatchedItem {
         state: map_item_state(&issue.state),
         is_draft: false,
         reviewers: Vec::new(),
+        commenters,
         ci_status: None,
     }
 }
@@ -970,7 +1020,53 @@ mod tests {
         assert_eq!(item.state, "open");
         assert!(!item.is_draft);
         assert!(item.reviewers.is_empty());
+        assert!(item.commenters.is_empty());
         assert!(item.ci_status.is_none());
+    }
+
+    fn make_issue_node_with_comments(nodes: serde_json::Value) -> IssueNode {
+        serde_json::from_value(json!({
+            "databaseId": 1,
+            "title": "t",
+            "number": 1,
+            "url": "https://github.com/o/r/issues/1",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "state": "OPEN",
+            "comments": { "totalCount": 0, "nodes": nodes },
+            "repository": { "nameWithOwner": "o/r" },
+            "author": { "login": "author", "avatarUrl": "a" }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn issue_commenters_dedupe_by_login_preserving_first_seen_order() {
+        let item = issue_to_item(make_issue_node_with_comments(json!([
+            { "author": { "login": "alice", "avatarUrl": "a" } },
+            { "author": { "login": "bob",   "avatarUrl": "b" } },
+            { "author": { "login": "alice", "avatarUrl": "a" } }
+        ])));
+        let logins: Vec<_> = item.commenters.iter().map(|c| c.login.as_str()).collect();
+        assert_eq!(logins, vec!["alice", "bob"]);
+    }
+
+    #[test]
+    fn issue_commenters_skip_anonymous_and_null_nodes() {
+        // A deleted-user GitHub comment surfaces as `author: null`; skip it
+        // rather than pushing an empty-login chip.
+        let item = issue_to_item(make_issue_node_with_comments(json!([
+            { "author": null },
+            { "author": { "login": "alice", "avatarUrl": "a" } }
+        ])));
+        let logins: Vec<_> = item.commenters.iter().map(|c| c.login.as_str()).collect();
+        assert_eq!(logins, vec!["alice"]);
+    }
+
+    #[test]
+    fn issue_commenters_empty_when_no_comments_field_nodes() {
+        // Legacy/older backend shape without `nodes` must still deserialize.
+        let item = issue_to_item(make_issue_node(10, "o/r", 7));
+        assert!(item.commenters.is_empty());
     }
 
     #[test]

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -24,6 +24,7 @@ function makeItem(
     state: "open",
     is_draft: false,
     reviewers: [],
+    commenters: [],
     ci_status: null,
     ...overrides,
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,11 @@ export type Reviewer = {
     | "pending";
 };
 
+export type Commenter = {
+  login: string;
+  avatar_url: string;
+};
+
 export type CiStatus = "success" | "pending" | "failure" | "error" | "unknown";
 
 export type WatchedItem = {
@@ -25,6 +30,7 @@ export type WatchedItem = {
   state: string;
   is_draft: boolean;
   reviewers: Reviewer[];
+  commenters: Commenter[];
   ci_status: CiStatus | null;
 };
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1078,6 +1078,21 @@
                           {/each}
                         </span>
                       {/if}
+                      {#if item.commenters.length > 0}
+                        <span class="commenters">
+                          {#each item.commenters as c (c.login)}
+                            <span class="commenter-chip" title={c.login}>
+                              <img
+                                class="commenter-chip-avatar"
+                                src={c.avatar_url}
+                                alt=""
+                                loading="lazy"
+                              />
+                              <span class="commenter-chip-name">{c.login}</span>
+                            </span>
+                          {/each}
+                        </span>
+                      {/if}
                     </span>
                   </button>
                   {#if activeTab === "hidden"}
@@ -1757,6 +1772,41 @@
     text-decoration: line-through;
   }
 
+  .commenters {
+    display: flex;
+    gap: 4px;
+    margin-top: 4px;
+    flex-wrap: wrap;
+  }
+
+  .commenter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px 2px 2px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    max-width: 100%;
+    min-width: 0;
+    background: rgba(87, 96, 106, 0.15);
+    color: #57606a;
+  }
+
+  .commenter-chip-avatar {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .commenter-chip-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
   @media (prefers-color-scheme: dark) {
     :global(:root) {
       color: #ececef;
@@ -1841,6 +1891,10 @@
     .reviewer-dismissed {
       background: rgba(139, 148, 158, 0.12);
       color: rgba(139, 148, 158, 0.7);
+    }
+    .commenter-chip {
+      background: rgba(139, 148, 158, 0.2);
+      color: #8b949e;
     }
     .row-action {
       color: rgba(236, 236, 239, 0.4);


### PR DESCRIPTION
## Summary
- Issue 行にコメント者（直近20件、ログインで重複排除）のアバター+ログインチップを追加。コメント数だけだった表示から「誰が議論しているか」がひと目で分かるようになる。
- GraphQL `IssueFields` フラグメントを拡張し、Rust 側で `Commenter` 型と `WatchedItem.commenters` を追加。削除ユーザ (`author: null`) はスキップ。
- フロント側は reviewer チップと視覚的に区別するためニュートラルなグレー系の配色で描画。

## Test plan
- [x] `cd src-tauri && cargo test --lib` (32 passed)
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] `pnpm check` (0 errors)
- [x] `pnpm test` (25 passed)
- [ ] `pnpm tauri dev` で Issue 行にコメント者チップが出ることを手動確認（コメントありの Issue / コメントなしの Issue / 削除ユーザのコメント）

🤖 Generated with [Claude Code](https://claude.com/claude-code)