### PR TITLE
style: blend scrollbar into popup theme

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1159,6 +1159,36 @@
     padding: 0;
   }
 
+  .list,
+  .settings {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
+  }
+
+  .list::-webkit-scrollbar,
+  .settings::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .list::-webkit-scrollbar-track,
+  .settings::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .list::-webkit-scrollbar-thumb,
+  .settings::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+
+  .list::-webkit-scrollbar-thumb:hover,
+  .settings::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(0, 0, 0, 0.35);
+    background-clip: content-box;
+  }
+
   .container {
     display: flex;
     flex-direction: column;
@@ -1951,6 +1981,18 @@
       color: #8b949e;
       background: rgba(139, 148, 158, 0.18);
       border-color: rgba(139, 148, 158, 0.5);
+    }
+    .list,
+    .settings {
+      scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+    }
+    .list::-webkit-scrollbar-thumb,
+    .settings::-webkit-scrollbar-thumb {
+      background-color: rgba(255, 255, 255, 0.18);
+    }
+    .list::-webkit-scrollbar-thumb:hover,
+    .settings::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(255, 255, 255, 0.32);
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- Popup のデフォルトスクロールバーがダーク背景に対して白く浮いて見えていたので、テーマに馴染む細身の半透明スクロールバーに差し替え
- `.list` と `.settings` 両方に適用、ライト/ダークモードそれぞれで thumb の色を調整（ホバーで濃くなる）
- トラックは透明にして本体背景と一体化

## Test plan
- [ ] `pnpm tauri dev` で popup を開き、リスト/設定画面のスクロールバーがダーク背景に馴染んでいるか確認
- [ ] ライトモードに切り替えて同様に違和感がないか確認
- [ ] thumb ホバー時に色が濃くなるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)