### PR TITLE
Confirm before installing app updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ^2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.0
+        version: 2.7.0
       '@tauri-apps/plugin-global-shortcut':
         specifier: ^2.3.1
         version: 2.3.1
@@ -553,6 +556,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
 
   '@tauri-apps/plugin-global-shortcut@2.3.1':
     resolution: {integrity: sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g==}
@@ -1374,6 +1380,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
   '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1081,6 +1081,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -3907,6 +3908,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,6 +4957,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,4 +31,5 @@ tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-autostart = "2.5.1"
+tauri-plugin-dialog = "2.7.0"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:default",
     "notification:default",
     "updater:default",
     "process:default",

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -211,3 +211,16 @@ pub fn sign_out(auth: State<'_, Mutex<AppState>>) {
 pub fn set_window_pinned(pinned: bool, auth: State<'_, Mutex<AppState>>) {
     auth.lock().unwrap().pinned = pinned;
 }
+
+/// Put the popup into "dialog mode": pinned (so focus loss won't auto-hide)
+/// and not always-on-top (so a native dialog can actually appear above it).
+/// Revert with `dialog_mode=false` when the dialog is dismissed.
+#[tauri::command]
+pub fn set_dialog_mode(
+    enabled: bool,
+    window: tauri::WebviewWindow,
+    auth: State<'_, Mutex<AppState>>,
+) {
+    auth.lock().unwrap().pinned = enabled;
+    let _ = window.set_always_on_top(!enabled);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -45,6 +46,7 @@ pub fn run() {
             auth::poll_device_flow,
             auth::sign_out,
             auth::set_window_pinned,
+            auth::set_dialog_mode,
             github::fetch_watched,
             github::fetch_notifications,
             github::mark_notification_read,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
     isPermissionGranted,
     requestPermission,
   } from "@tauri-apps/plugin-notification";
-  import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
+  import { check as checkForUpdate, Update } from "@tauri-apps/plugin-updater";
   import { relaunch } from "@tauri-apps/plugin-process";
   import { ask, message } from "@tauri-apps/plugin-dialog";
   import {
@@ -93,14 +93,12 @@
     | { kind: "idle" }
     | { kind: "checking" }
     | { kind: "up-to-date" }
-    | { kind: "available"; version: string }
+    | { kind: "available"; update: Update }
     | { kind: "downloading" }
     | { kind: "installed" }
     | { kind: "error"; message: string };
   let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   let appVersion = $state<string>("");
-  type PendingUpdate = NonNullable<Awaited<ReturnType<typeof checkForUpdate>>>;
-  let pendingUpdate: PendingUpdate | null = null;
   let autostartEnabled = $state<boolean | null>(null);
   const excludedRepos = new SvelteSet<string>(loadExcludedRepos());
   const hiddenItems = new SvelteSet<number>(loadHiddenItems());
@@ -407,7 +405,6 @@
     try {
       const update = await checkForUpdate();
       if (!update) {
-        pendingUpdate = null;
         updateStatus = { kind: "up-to-date" };
         console.info("[eir] update check: already latest");
         if (opts.interactive) {
@@ -423,21 +420,13 @@
       console.info(
         `[eir] update check: ${update.version} available (current ${update.currentVersion})`,
       );
-      pendingUpdate = update;
-      updateStatus = { kind: "available", version: update.version };
+      updateStatus = { kind: "available", update };
       if (!opts.interactive && notifyEnabled) {
-        // Silent check on boot — let the user know via a desktop notification
-        // that a new version is ready. They decide whether to install from
-        // Settings; we never auto-install.
-        try {
-          if (await ensureNotificationPermission()) {
-            showNotification(
-              "eir update available",
-              `Version ${update.version} is ready. Open Settings to install.`,
-            );
-          }
-        } catch {
-          // ignore
+        if (await ensureNotificationPermission()) {
+          showNotification(
+            "eir update available",
+            `Version ${update.version} is ready. Open Settings to install.`,
+          );
         }
       }
     } catch (e) {
@@ -448,16 +437,15 @@
   }
 
   async function installPendingUpdate() {
-    if (!pendingUpdate) return;
-    if (updateStatus.kind === "downloading") return;
+    if (updateStatus.kind !== "available") return;
+    const update = updateStatus.update;
     const ok = await withPinnedWindow(() =>
       ask(
-        `Install eir v${pendingUpdate!.version}?\n\nThe app will relaunch after the update is installed.`,
+        `Install eir v${update.version}?\n\nThe app will relaunch after the update is installed.`,
         { title: "Update available", kind: "info", okLabel: "Install" },
       ),
     );
     if (!ok) return;
-    const update = pendingUpdate;
     updateStatus = { kind: "downloading" };
     try {
       await update.downloadAndInstall();
@@ -488,37 +476,27 @@
   }
 
   onMount(async () => {
-    // Kick the permission dialog early so the first real notification isn't
-    // also the first time the OS is asked — which silently denies in some
-    // cases on macOS dev builds.
-    try {
-      await ensureNotificationPermission();
-    } catch {
-      // ignore
-    }
-    try {
-      toggleShortcut = await invoke<string>("get_toggle_shortcut");
-    } catch {
-      // keep default
-    }
-    try {
-      appVersion = await getVersion();
-    } catch {
-      // leave empty
-    }
     window.addEventListener("keydown", handleGlobalKey);
     void loadItems({ silent: true });
     // Silent update check on boot — if a new version is out, the Settings
     // button will show "Update available" and the user can choose to install.
     void runUpdateCheck({ interactive: false });
-    // Sync the autostart toggle with the actual system state. The plugin
-    // reads the LaunchAgent plist, so this catches changes made outside
-    // the app (e.g. the user disabled "Login Items" in System Settings).
-    try {
-      autostartEnabled = await isAutostartEnabled();
-    } catch {
-      autostartEnabled = false;
-    }
+
+    // Kick the permission dialog early so the first real notification isn't
+    // also the first time the OS is asked — which silently denies in some
+    // cases on macOS dev builds.
+    const [, shortcut, version, autostart] = await Promise.all([
+      ensureNotificationPermission().catch(() => false),
+      invoke<string>("get_toggle_shortcut").catch(() => null),
+      getVersion().catch(() => ""),
+      // Sync the autostart toggle with the actual system state — the plugin
+      // reads the LaunchAgent plist, so this catches changes made outside
+      // the app (e.g. the user disabled "Login Items" in System Settings).
+      isAutostartEnabled().catch(() => false),
+    ]);
+    if (shortcut) toggleShortcut = shortcut;
+    appVersion = version;
+    autostartEnabled = autostart;
   });
 
   onDestroy(() => {
@@ -885,7 +863,7 @@
               <span class="setting-hint-inline">· already latest</span>
             {:else if updateStatus.kind === "available"}
               <span class="setting-hint-inline update-available"
-                >· v{updateStatus.version} available</span
+                >· v{updateStatus.update.version} available</span
               >
             {:else if updateStatus.kind === "installed"}
               <span class="setting-hint-inline">· installed, relaunching…</span>
@@ -909,7 +887,7 @@
             {:else if updateStatus.kind === "downloading"}
               Installing…
             {:else if updateStatus.kind === "available"}
-              Install v{updateStatus.version}
+              Install v{updateStatus.update.version}
             {:else}
               Check
             {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   } from "@tauri-apps/plugin-notification";
   import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
   import { relaunch } from "@tauri-apps/plugin-process";
+  import { ask, message } from "@tauri-apps/plugin-dialog";
   import {
     disable as disableAutostart,
     enable as enableAutostart,
@@ -98,6 +99,8 @@
     | { kind: "error"; message: string };
   let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   let appVersion = $state<string>("");
+  type PendingUpdate = NonNullable<Awaited<ReturnType<typeof checkForUpdate>>>;
+  let pendingUpdate: PendingUpdate | null = null;
   let autostartEnabled = $state<boolean | null>(null);
   const excludedRepos = new SvelteSet<string>(loadExcludedRepos());
   const hiddenItems = new SvelteSet<number>(loadHiddenItems());
@@ -385,6 +388,18 @@
     }
   }
 
+  async function withPinnedWindow<T>(fn: () => Promise<T>): Promise<T> {
+    // Pin the popup (so focus loss doesn't auto-hide it) AND drop always-on-top
+    // so the native dialog can actually render above the popup instead of
+    // getting buried underneath it.
+    await invoke("set_dialog_mode", { enabled: true });
+    try {
+      return await fn();
+    } finally {
+      await invoke("set_dialog_mode", { enabled: false });
+    }
+  }
+
   async function runUpdateCheck(opts: { interactive: boolean }) {
     if (updateStatus.kind === "checking" || updateStatus.kind === "downloading")
       return;
@@ -392,26 +407,65 @@
     try {
       const update = await checkForUpdate();
       if (!update) {
+        pendingUpdate = null;
         updateStatus = { kind: "up-to-date" };
         console.info("[eir] update check: already latest");
+        if (opts.interactive) {
+          await withPinnedWindow(() =>
+            message(
+              `You're on the latest version${appVersion ? ` (v${appVersion})` : ""}.`,
+              { title: "eir", kind: "info" },
+            ),
+          );
+        }
         return;
       }
       console.info(
         `[eir] update check: ${update.version} available (current ${update.currentVersion})`,
       );
+      pendingUpdate = update;
       updateStatus = { kind: "available", version: update.version };
-      if (!opts.interactive) {
-        // Silent check on boot — just record availability, let the user
-        // click the Settings button when they're ready. No auto-install.
-        return;
+      if (!opts.interactive && notifyEnabled) {
+        // Silent check on boot — let the user know via a desktop notification
+        // that a new version is ready. They decide whether to install from
+        // Settings; we never auto-install.
+        try {
+          if (await ensureNotificationPermission()) {
+            showNotification(
+              "eir update available",
+              `Version ${update.version} is ready. Open Settings to install.`,
+            );
+          }
+        } catch {
+          // ignore
+        }
       }
-      updateStatus = { kind: "downloading" };
+    } catch (e) {
+      const message = String(e);
+      console.warn("[eir] update check failed:", message);
+      updateStatus = { kind: "error", message };
+    }
+  }
+
+  async function installPendingUpdate() {
+    if (!pendingUpdate) return;
+    if (updateStatus.kind === "downloading") return;
+    const ok = await withPinnedWindow(() =>
+      ask(
+        `Install eir v${pendingUpdate!.version}?\n\nThe app will relaunch after the update is installed.`,
+        { title: "Update available", kind: "info", okLabel: "Install" },
+      ),
+    );
+    if (!ok) return;
+    const update = pendingUpdate;
+    updateStatus = { kind: "downloading" };
+    try {
       await update.downloadAndInstall();
       updateStatus = { kind: "installed" };
       await relaunch();
     } catch (e) {
       const message = String(e);
-      console.warn("[eir] update check failed:", message);
+      console.warn("[eir] update install failed:", message);
       updateStatus = { kind: "error", message };
     }
   }
@@ -845,7 +899,10 @@
             class="secondary"
             disabled={updateStatus.kind === "checking" ||
               updateStatus.kind === "downloading"}
-            onclick={() => runUpdateCheck({ interactive: true })}
+            onclick={() =>
+              updateStatus.kind === "available"
+                ? installPendingUpdate()
+                : runUpdateCheck({ interactive: true })}
           >
             {#if updateStatus.kind === "checking"}
               Checking…


### PR DESCRIPTION
## Summary
- Stop auto-installing when "Check for updates" finds a new version. The check only caches the update now; a separate "Install vX.Y.Z" button triggers the actual download + relaunch after a native `ask()` confirmation.
- Interactive check shows a native message when already on the latest version (so users get visible feedback in the "nothing to do" case).
- Silent boot check posts a desktop notification when an update is available, so users know to open Settings.
- Add `set_dialog_mode` command that pins the popup and drops `alwaysOnTop` while a dialog is up — without this, the popup's always-on-top behavior buried the NSAlert underneath it and/or the focus-loss auto-hide closed the popup mid-dialog.

## Test plan
- [ ] `pnpm tauri dev`, open Settings, click "Check" → confirm "You're on the latest version" dialog appears above the popup and popup stays open
- [ ] If/when an update is genuinely available: verify "Install vX" button triggers the confirmation and installs only on OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)