### PR TITLE
fix: popup UX polish — reset state, notify on close/merge, multi-monitor positioning

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -551,6 +551,138 @@ fn merge_search_results(data: std::collections::HashMap<String, SearchResult>) -
 }
 
 // ---------------------------------------------------------------------------
+// fetch_item_states — look up the final state (open/closed/merged) of a
+// list of PRs/Issues by (repo, kind, number). Used to precisely label
+// disappearance notifications: when an item drops out of the `is:open`
+// search result we want to say "Merged" vs "Closed" rather than guessing.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Clone)]
+pub struct ItemRef {
+    pub repo: String,
+    pub kind: String, // "pr" | "issue"
+    pub number: u64,
+}
+
+#[derive(Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct ItemState {
+    pub repo: String,
+    pub kind: &'static str,
+    pub number: u64,
+    pub state: &'static str, // "open" | "closed" | "merged" | "unknown"
+}
+
+/// Build the GraphQL query body (query string + variables) for a batch state
+/// lookup. Owner and name go through variables to avoid any string-escape
+/// surprises; number is inlined since it's a scalar from trusted data.
+fn build_item_states_query(items: &[ItemRef]) -> (String, serde_json::Map<String, serde_json::Value>) {
+    let mut var_decls: Vec<String> = Vec::new();
+    let mut aliases: Vec<String> = Vec::new();
+    let mut variables = serde_json::Map::new();
+
+    for (i, it) in items.iter().enumerate() {
+        let Some((owner, name)) = it.repo.split_once('/') else {
+            continue;
+        };
+        let sub = match it.kind.as_str() {
+            "pr" => format!("pullRequest(number: {}) {{ state }}", it.number),
+            "issue" => format!("issue(number: {}) {{ state }}", it.number),
+            _ => continue,
+        };
+        var_decls.push(format!("$o{i}: String!, $n{i}: String!"));
+        aliases.push(format!(
+            "  i{i}: repository(owner: $o{i}, name: $n{i}) {{ {sub} }}"
+        ));
+        variables.insert(format!("o{i}"), serde_json::Value::String(owner.to_string()));
+        variables.insert(format!("n{i}"), serde_json::Value::String(name.to_string()));
+    }
+
+    let query = format!(
+        "query Q({vars}) {{\n{aliases}\n}}",
+        vars = var_decls.join(", "),
+        aliases = aliases.join("\n"),
+    );
+    (query, variables)
+}
+
+fn parse_item_state(resp: &serde_json::Value, index: usize, kind: &str) -> &'static str {
+    let alias = format!("i{index}");
+    let Some(node) = resp.get("data").and_then(|d| d.get(&alias)) else {
+        return "unknown";
+    };
+    let inner_key = match kind {
+        "pr" => "pullRequest",
+        "issue" => "issue",
+        _ => return "unknown",
+    };
+    let raw = node
+        .get(inner_key)
+        .and_then(|v| v.get("state"))
+        .and_then(|s| s.as_str())
+        .unwrap_or("");
+    map_item_state(raw)
+}
+
+#[tauri::command]
+pub async fn fetch_item_states(
+    items: Vec<ItemRef>,
+    auth: State<'_, Mutex<AppState>>,
+) -> Result<Vec<ItemState>, String> {
+    if items.is_empty() {
+        return Ok(Vec::new());
+    }
+    let octo = build_octo(&auth)?;
+
+    let (query, variables) = build_item_states_query(&items);
+    let body = serde_json::json!({ "query": query, "variables": variables });
+
+    let resp: serde_json::Value = match octo.graphql(&body).await {
+        Ok(v) => v,
+        Err(err) => {
+            if is_unauthorized(&err) {
+                clear_stored_token(&auth);
+                return Err("not_authenticated".into());
+            }
+            return Err(err.to_string());
+        }
+    };
+
+    // Bubble GraphQL-level errors (e.g. a repo we no longer have access to)
+    // rather than silently returning "unknown" for every item — that would
+    // mask a real failure.
+    if let Some(errors) = resp.get("errors").and_then(|e| e.as_array()) {
+        if !errors.is_empty() {
+            let joined = errors
+                .iter()
+                .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                .collect::<Vec<_>>()
+                .join("; ");
+            if !joined.is_empty() {
+                return Err(joined);
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(items.len());
+    for (i, it) in items.iter().enumerate() {
+        let kind: &'static str = match it.kind.as_str() {
+            "pr" => "pr",
+            "issue" => "issue",
+            _ => continue,
+        };
+        let state = parse_item_state(&resp, i, kind);
+        out.push(ItemState {
+            repo: it.repo.clone(),
+            kind,
+            number: it.number,
+            state,
+        });
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
 // Notifications — GitHub's GraphQL schema does not expose the notifications
 // inbox or mark-as-read, so these remain REST.
 // ---------------------------------------------------------------------------
@@ -1168,6 +1300,99 @@ mod tests {
         )]);
         let out = merge_search_results(data);
         assert_eq!(out.len(), 1);
+    }
+
+    fn make_item_ref(repo: &str, kind: &str, number: u64) -> ItemRef {
+        ItemRef {
+            repo: repo.to_string(),
+            kind: kind.to_string(),
+            number,
+        }
+    }
+
+    #[test]
+    fn build_item_states_query_uses_variables_for_owner_and_name() {
+        let (query, variables) = build_item_states_query(&[
+            make_item_ref("owner1/repo1", "pr", 10),
+            make_item_ref("owner2/repo2", "issue", 20),
+        ]);
+
+        // Each item gets its own aliased variables.
+        assert!(query.contains("$o0: String!, $n0: String!"));
+        assert!(query.contains("$o1: String!, $n1: String!"));
+        // Aliased repositories using those variables.
+        assert!(query.contains("i0: repository(owner: $o0, name: $n0)"));
+        assert!(query.contains("i1: repository(owner: $o1, name: $n1)"));
+        // Sub-selection differs by kind.
+        assert!(query.contains("pullRequest(number: 10) { state }"));
+        assert!(query.contains("issue(number: 20) { state }"));
+        // Variables carry the owner/name values.
+        assert_eq!(variables.get("o0").and_then(|v| v.as_str()), Some("owner1"));
+        assert_eq!(variables.get("n0").and_then(|v| v.as_str()), Some("repo1"));
+        assert_eq!(variables.get("o1").and_then(|v| v.as_str()), Some("owner2"));
+        assert_eq!(variables.get("n1").and_then(|v| v.as_str()), Some("repo2"));
+    }
+
+    #[test]
+    fn build_item_states_query_skips_malformed_repo() {
+        // A repo without a "/" is defensive-skipped; its slot simply doesn't
+        // appear in the query rather than producing a malformed GraphQL.
+        let (query, variables) = build_item_states_query(&[
+            make_item_ref("no-slash", "pr", 1),
+            make_item_ref("owner/repo", "pr", 2),
+        ]);
+        assert!(!query.contains("$o0"));
+        assert!(query.contains("$o1"));
+        assert!(!variables.contains_key("o0"));
+        assert!(variables.contains_key("o1"));
+    }
+
+    #[test]
+    fn build_item_states_query_skips_unknown_kind() {
+        let (query, _) = build_item_states_query(&[
+            make_item_ref("owner/repo", "discussion", 1),
+            make_item_ref("owner/repo", "pr", 2),
+        ]);
+        assert!(!query.contains("$o0"));
+        assert!(query.contains("$o1"));
+    }
+
+    #[test]
+    fn parse_item_state_maps_merged_closed_open() {
+        let resp = json!({
+            "data": {
+                "i0": { "pullRequest": { "state": "MERGED" } },
+                "i1": { "pullRequest": { "state": "CLOSED" } },
+                "i2": { "issue": { "state": "CLOSED" } },
+                "i3": { "issue": { "state": "OPEN" } }
+            }
+        });
+        assert_eq!(parse_item_state(&resp, 0, "pr"), "merged");
+        assert_eq!(parse_item_state(&resp, 1, "pr"), "closed");
+        assert_eq!(parse_item_state(&resp, 2, "issue"), "closed");
+        assert_eq!(parse_item_state(&resp, 3, "issue"), "open");
+    }
+
+    #[test]
+    fn parse_item_state_returns_unknown_for_missing_alias() {
+        let resp = json!({ "data": { "i0": { "pullRequest": { "state": "MERGED" } } } });
+        // Alias i99 isn't in the response — don't blow up, just say unknown.
+        assert_eq!(parse_item_state(&resp, 99, "pr"), "unknown");
+    }
+
+    #[test]
+    fn parse_item_state_returns_unknown_for_deleted_repo() {
+        // GitHub returns `null` for the repository alias when the repo was
+        // deleted or we lost access. The parser should fall back to unknown
+        // instead of panicking.
+        let resp = json!({ "data": { "i0": null } });
+        assert_eq!(parse_item_state(&resp, 0, "pr"), "unknown");
+    }
+
+    #[test]
+    fn parse_item_state_returns_unknown_for_unknown_kind() {
+        let resp = json!({ "data": { "i0": { "pullRequest": { "state": "MERGED" } } } });
+        assert_eq!(parse_item_state(&resp, 0, "commit"), "unknown");
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -576,7 +576,9 @@ pub struct ItemState {
 /// Build the GraphQL query body (query string + variables) for a batch state
 /// lookup. Owner and name go through variables to avoid any string-escape
 /// surprises; number is inlined since it's a scalar from trusted data.
-fn build_item_states_query(items: &[ItemRef]) -> (String, serde_json::Map<String, serde_json::Value>) {
+fn build_item_states_query(
+    items: &[ItemRef],
+) -> (String, serde_json::Map<String, serde_json::Value>) {
     let mut var_decls: Vec<String> = Vec::new();
     let mut aliases: Vec<String> = Vec::new();
     let mut variables = serde_json::Map::new();
@@ -594,7 +596,10 @@ fn build_item_states_query(items: &[ItemRef]) -> (String, serde_json::Map<String
         aliases.push(format!(
             "  i{i}: repository(owner: $o{i}, name: $n{i}) {{ {sub} }}"
         ));
-        variables.insert(format!("o{i}"), serde_json::Value::String(owner.to_string()));
+        variables.insert(
+            format!("o{i}"),
+            serde_json::Value::String(owner.to_string()),
+        );
         variables.insert(format!("n{i}"), serde_json::Value::String(name.to_string()));
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod tray;
 
 use std::sync::Mutex;
 
-use tauri::{Manager, WindowEvent};
+use tauri::{Emitter, Manager, WindowEvent};
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
@@ -49,6 +49,7 @@ pub fn run() {
             auth::set_dialog_mode,
             github::fetch_watched,
             github::fetch_notifications,
+            github::fetch_item_states,
             github::mark_notification_read,
             tray::set_tray_badge,
             shortcut::get_toggle_shortcut,
@@ -77,6 +78,7 @@ pub fn run() {
                     .pinned;
                 if !pinned {
                     let _ = window.hide();
+                    let _ = window.app_handle().emit(tray::POPUP_HIDDEN_EVENT, ());
                 }
             }
         })

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,8 +2,13 @@ use tauri::{
     image::Image,
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    App, Manager, PhysicalPosition,
+    App, Emitter, Manager, PhysicalPosition,
 };
+
+/// Event emitted to the webview when the popup transitions from visible to
+/// hidden. The frontend listens for this to reset transient UI state (e.g.
+/// the Settings panel) so reopening starts from the list view.
+pub const POPUP_HIDDEN_EVENT: &str = "popup-hidden";
 
 // macOS uses a template-mode monochrome icon so the system can tint it based
 // on menubar state (dark/light/focus). Windows and Linux taskbars don't
@@ -62,6 +67,7 @@ pub fn toggle_popup(app: &tauri::AppHandle) {
     };
     if window.is_visible().unwrap_or(false) {
         let _ = window.hide();
+        let _ = app.emit(POPUP_HIDDEN_EVENT, ());
         return;
     }
     position_near_tray(app, &window);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -61,7 +61,22 @@ pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
 
 /// Toggle the popup window. If visible, hide it. If hidden, position it
 /// near the tray icon and show it.
+///
+/// All NSWindow-mutating work is dispatched onto the main thread. The tray
+/// click path is already on the main thread so this is a no-op hop, but
+/// the global-shortcut handler runs on the shortcut listener thread and
+/// must cross over — calling `set_position` / `set_size` / `show` directly
+/// from that thread risks each call being queued onto the main thread
+/// individually, which can reorder operations. Wrapping the whole sequence
+/// in a single main-thread closure makes the ordering deterministic.
 pub fn toggle_popup(app: &tauri::AppHandle) {
+    let app_handle = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        toggle_popup_on_main(&app_handle);
+    });
+}
+
+fn toggle_popup_on_main(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
     };
@@ -73,6 +88,36 @@ pub fn toggle_popup(app: &tauri::AppHandle) {
     position_near_tray(app, &window);
     let _ = window.show();
     let _ = window.set_focus();
+}
+
+/// Pick the monitor whose bounds contain the given point, falling back to
+/// the window's current monitor, then primary, then the first available.
+///
+/// `window.current_monitor()` alone is unreliable in multi-monitor setups:
+/// it returns whichever monitor the window was last shown on, so if the
+/// popup was previously open on the main monitor and the user clicks the
+/// tray on a secondary monitor, the returned bounds describe the *wrong*
+/// screen and the popup snaps to the edge of the main monitor instead of
+/// appearing under the tray icon the user actually clicked.
+fn monitor_containing(window: &tauri::WebviewWindow, x: i32, y: i32) -> Option<tauri::Monitor> {
+    let monitors = window.available_monitors().ok().unwrap_or_default();
+    if let Some(m) = monitors.iter().find(|m| {
+        let p = m.position();
+        let s = m.size();
+        let left = p.x;
+        let right = p.x + s.width as i32;
+        let top = p.y;
+        let bottom = p.y + s.height as i32;
+        x >= left && x < right && y >= top && y < bottom
+    }) {
+        return Some(m.clone());
+    }
+    window
+        .current_monitor()
+        .ok()
+        .flatten()
+        .or_else(|| window.primary_monitor().ok().flatten())
+        .or_else(|| monitors.into_iter().next())
 }
 
 fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
@@ -95,9 +140,13 @@ fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
 
     let win_size = window.outer_size().unwrap_or_default();
     let popup_width = win_size.width as i32;
-    let popup_height = win_size.height as i32;
+    let current_popup_height = win_size.height as i32;
 
-    let monitor = window.current_monitor().ok().flatten();
+    // Pick the monitor that physically contains the tray icon — not whichever
+    // monitor the window happens to be sitting on. Matches the user's click.
+    let tray_center_x = tray_x + tray_w / 2;
+    let tray_center_y = tray_y + tray_h / 2;
+    let monitor = monitor_containing(window, tray_center_x, tray_center_y);
     let (monitor_top, monitor_bottom, monitor_left, monitor_right) = match monitor.as_ref() {
         Some(m) => {
             let pos = m.position();
@@ -115,41 +164,36 @@ fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
     // Decide above vs below: tray closer to the top of the monitor → drop the
     // popup below it (macOS menubar). Tray closer to the bottom → raise the
     // popup above it (Windows taskbar / KDE default).
-    let tray_center_y = tray_y + tray_h / 2;
     let monitor_mid_y = monitor_top + (monitor_bottom - monitor_top) / 2;
     let open_below = tray_center_y < monitor_mid_y;
 
-    // On macOS we take advantage of having the tray at the top to grow the
-    // popup to fill most of the screen height. On Windows/Linux the tray
-    // isn't consistently at one edge, so we stick with the configured size.
+    // Compute the target size first — no side effects yet. On macOS we take
+    // advantage of having the tray at the top to grow the popup to fill most
+    // of the screen height. On Windows/Linux the tray isn't consistently at
+    // one edge, so we stick with the current size.
     #[cfg(target_os = "macos")]
-    let popup_height = {
-        if let Some(m) = monitor.as_ref() {
+    let target_height = match monitor.as_ref() {
+        Some(m) => {
             let dock_margin = (80.0 * m.scale_factor()) as i32;
             let bottom = monitor_top + m.size().height as i32;
-            let popup_top = tray_y + tray_h + 8;
-            let target_height = (bottom - popup_top - dock_margin).max(400);
-            let _ = window.set_size(tauri::PhysicalSize {
-                width: popup_width as u32,
-                height: target_height as u32,
-            });
-            target_height
-        } else {
-            popup_height
+            let top_if_below = tray_y + tray_h + 8;
+            (bottom - top_if_below - dock_margin).max(400)
         }
+        None => current_popup_height,
     };
+    #[cfg(not(target_os = "macos"))]
+    let target_height = current_popup_height;
 
     let popup_top = if open_below {
         tray_y + tray_h + 8
     } else {
-        // Subtract the (possibly resized) height; fall back to tray_y - 8 if we
-        // can't determine a reasonable anchor.
-        (tray_y - popup_height - 8).max(monitor_top + 8)
+        // Subtract the target height; fall back to tray_y - 8 if we can't
+        // determine a reasonable anchor.
+        (tray_y - target_height - 8).max(monitor_top + 8)
     };
 
-    let tray_center_x = tray_x + tray_w / 2;
     let mut x = tray_center_x - popup_width / 2;
-    // Keep the window fully on the current monitor.
+    // Keep the window fully on the target monitor.
     let max_x = monitor_right - popup_width - 8;
     let min_x = monitor_left + 8;
     if x > max_x {
@@ -159,6 +203,20 @@ fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
         x = min_x;
     }
 
+    // Apply in an order that avoids a cross-monitor flash. The window is
+    // still hidden here, but on macOS `set_size` resolves against whichever
+    // screen the NSWindow is currently anchored to — typically the monitor
+    // where it was last shown. If we size first, show() briefly renders the
+    // resized window on the *old* monitor before our position update moves
+    // it, which the user sees as a flicker. Setting the position first
+    // anchors the window to the target monitor so the resize happens in the
+    // right context; a second set_position call after set_size covers any
+    // implicit origin adjustment macOS may perform when the frame grows.
+    let _ = window.set_position(PhysicalPosition { x, y: popup_top });
+    let _ = window.set_size(tauri::PhysicalSize {
+        width: popup_width as u32,
+        height: target_height as u32,
+    });
     let _ = window.set_position(PhysicalPosition { x, y: popup_top });
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { getVersion } from "@tauri-apps/api/app";
+  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import {
     isPermissionGranted,
@@ -110,6 +111,7 @@
   let prevItems = new Map<number, WatchedItem>();
   let hasLoadedOnce = false;
   let refreshTimer: ReturnType<typeof setInterval> | null = null;
+  let unlistenPopupHidden: UnlistenFn | null = null;
 
   function loadTabFromStorage(): Tab {
     const raw = localStorage.getItem(TAB_KEY);
@@ -264,11 +266,27 @@
         console.info(
           `[eir] refresh: ${fetchedNotifs.length} unread notifications (${fresh.length} new), ${itemChanges.length} item-level changes`,
         );
+        // Items in prev but missing from curr disappeared upstream. The
+        // search query is `is:open`, so in practice this means the item was
+        // closed / merged / archived (or moved out of scope, which is rare
+        // enough to tolerate as a false-positive "Closed" ping).
+        const currIds = new Set(fetchedItems.map((i) => i.id));
+        const removed: WatchedItem[] = [];
+        for (const [id, prev] of prevItems) {
+          if (currIds.has(id)) continue;
+          if (notifiedKeys.has(itemKey(prev))) continue;
+          removed.push(prev);
+        }
+
         if (fresh.length > 0) {
           await notify(fresh);
         }
         if (itemChanges.length > 0) {
           await notifyItemChanges(itemChanges);
+        }
+        if (removed.length > 0) {
+          const entries = await resolveRemovedStates(removed);
+          await notifyRemoved(entries);
         }
       } else {
         console.info(
@@ -328,6 +346,57 @@
       default:
         return "New activity";
     }
+  }
+
+  type RemovedEntry = { item: WatchedItem; state: string };
+
+  async function notifyRemoved(entries: RemovedEntry[]) {
+    if (!notifyEnabled) return;
+    if (!(await ensureNotificationPermission())) return;
+    for (const { item, state } of entries) {
+      const title = state === "merged" ? "Merged" : "Closed";
+      console.info(
+        `[eir] sending removal notification: ${title} — ${item.repo}#${item.number}`,
+      );
+      showNotification(
+        title,
+        `${item.repo}#${item.number} — ${item.title}`,
+        item.url,
+      );
+    }
+  }
+
+  async function resolveRemovedStates(
+    removed: WatchedItem[],
+  ): Promise<RemovedEntry[]> {
+    if (removed.length === 0) return [];
+    const refs = removed.map((i) => ({
+      repo: i.repo,
+      kind: i.kind,
+      number: i.number,
+    }));
+    type StateRow = {
+      repo: string;
+      kind: "pr" | "issue";
+      number: number;
+      state: string;
+    };
+    // A failed lookup (network blip, rate limit, etc.) shouldn't suppress the
+    // whole batch — fall back to an empty map so each item ends up labelled
+    // "Closed" by default, which is still better than silence.
+    const states = await invoke<StateRow[]>("fetch_item_states", {
+      items: refs,
+    }).catch((err) => {
+      console.warn("[eir] fetch_item_states failed:", err);
+      return [] as StateRow[];
+    });
+    const byKey = new Map<string, string>(
+      states.map((s) => [`${s.repo}:${s.kind}:${s.number}`, s.state]),
+    );
+    return removed.map((item) => ({
+      item,
+      state: byKey.get(itemKey(item)) ?? "closed",
+    }));
   }
 
   async function notifyItemChanges(
@@ -477,6 +546,20 @@
 
   onMount(async () => {
     window.addEventListener("keydown", handleGlobalKey);
+    // When the popup is hidden (focus loss or tray re-click), Settings is
+    // treated as transient: reopening should land back on the list scrolled
+    // to the top with the first item selected, so a fresh open feels like a
+    // fresh glance.
+    void listen("popup-hidden", () => {
+      showingSettings = false;
+      // Clear selection so the $effect picks flatItems[0] on next render;
+      // this also snaps keyboard nav back to the top.
+      selectedId = null;
+      const list = document.querySelector<HTMLElement>(".list");
+      if (list) list.scrollTop = 0;
+    }).then((fn) => {
+      unlistenPopupHidden = fn;
+    });
     void loadItems({ silent: true });
     // Silent update check on boot — if a new version is out, the Settings
     // button will show "Update available" and the user can choose to install.
@@ -502,6 +585,8 @@
   onDestroy(() => {
     stopRefresh();
     window.removeEventListener("keydown", handleGlobalKey);
+    unlistenPopupHidden?.();
+    unlistenPopupHidden = null;
   });
 
   function formatShortcut(e: KeyboardEvent): string | null {
@@ -738,6 +823,12 @@
     activeTab = tab;
     localStorage.setItem(TAB_KEY, tab);
     items = [];
+    // The diff anchors are per-tab: a different query returns a different
+    // set, so disappearing items aren't real closures and new items aren't
+    // genuinely new. Reset before refetching.
+    prevItems = new Map();
+    prevThreads = new Map();
+    hasLoadedOnce = false;
     await loadItems();
   }
 


### PR DESCRIPTION
## Summary

- **Reset popup state on hide** — Settings, selection, and scroll position are now treated as transient. Reopening the popup lands on the list scrolled to the top with the first item selected.
- **Notify on PR merge / Issue close** — items that drop out of the `is:open` search are diffed against the previous snapshot and surfaced as desktop notifications. A new `fetch_item_states` GraphQL command looks up the final state in one batched request so the label is accurately "Merged" vs "Closed".
- **Multi-monitor popup placement** — the popup is now anchored to the monitor that physically contains the tray icon, not whichever monitor the window happened to be on. Fixes sub-monitor tray clicks snapping to the edge of the main monitor. Also threads the entire window-mutation sequence through `run_on_main_thread` so the global-shortcut path has deterministic ordering.

## Test plan

- [ ] Multi-monitor: click the tray icon on the sub-monitor — popup appears directly under the tray, not on the main monitor's edge.
- [ ] Multi-monitor: press Ctrl+Shift+E while focused on the sub-monitor — popup appears on the correct monitor.
- [ ] Close an Issue you're watching — "Closed" notification fires.
- [ ] Merge a PR you're watching — "Merged" notification fires (distinct from "Closed").
- [ ] Open Settings, close popup, reopen — lands on the list, scrolled to top, first item selected.
- [ ] Switch tabs rapidly — no mass "New in list" notifications (diff state resets per tab).
- [ ] `pnpm test` passes (25 tests).
- [ ] `pnpm check` passes (0 errors).
- [ ] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] `cargo test --lib` passes (39 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)