### PR TITLE
Mark-all-read, broader Review tab, dynamic tray badge

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
 name = "eir"
 version = "0.4.1"
 dependencies = [
+ "image",
  "octocrab",
  "reqwest",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,4 +32,8 @@ tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-dialog = "2.7.0"
+# Used to synthesise the red-dot badge variant of the tray icon at startup.
+# Tauri already pulls `image` in via the `image-png` feature, but we list it
+# explicitly so the direct API usage has its own version pin.
+image = { version = "0.25", default-features = false, features = ["png"] }
 

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -68,7 +68,15 @@ pub struct WatchedItem {
 fn queries_for_tab(tab: &str, watched_orgs: &[String]) -> Vec<String> {
     match tab {
         "authored" => vec!["is:open is:pr author:@me archived:false".into()],
-        "review" => vec!["is:open is:pr review-requested:@me archived:false".into()],
+        // Two queries unioned via the GraphQL alias batching in `fetch_watched`:
+        // `review-requested` drops a PR out once you submit any review, so the
+        // tab used to "empty itself" after commenting/approving. Adding
+        // `reviewed-by` keeps PRs you've been assigned to — and touched —
+        // visible until they're closed.
+        "review" => vec![
+            "is:open is:pr review-requested:@me archived:false".into(),
+            "is:open is:pr reviewed-by:@me archived:false".into(),
+        ],
         "mentions" => vec!["is:open mentions:@me archived:false".into()],
         _ => {
             let mut qs = vec![
@@ -1080,6 +1088,21 @@ mod tests {
         let qs = queries_for_tab("authored", &["Lecto-inc".to_string()]);
         assert_eq!(qs.len(), 1);
         assert!(qs[0].contains("author:@me"));
+    }
+
+    #[test]
+    fn queries_for_tab_review_includes_requested_and_reviewed_by() {
+        let qs = queries_for_tab("review", &[]);
+        assert_eq!(qs.len(), 2);
+        assert!(qs.iter().any(|q| q.contains("review-requested:@me")));
+        assert!(qs.iter().any(|q| q.contains("reviewed-by:@me")));
+    }
+
+    #[test]
+    fn queries_for_tab_review_ignores_watched_orgs() {
+        let qs = queries_for_tab("review", &["Lecto-inc".to_string()]);
+        assert_eq!(qs.len(), 2);
+        assert!(qs.iter().all(|q| !q.contains("user:")));
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,3 +1,4 @@
+use std::sync::{Mutex, OnceLock};
 use tauri::{
     image::Image,
     menu::{Menu, MenuItem},
@@ -21,27 +22,89 @@ const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/32x32.png");
 
 const TRAY_ID: &str = "main";
 
+// Badge variant is synthesised once from TRAY_ICON_BYTES at startup. When
+// there are unread notifications we swap to this icon and disable template
+// mode so the red dot renders red — template mode would tint it to the
+// menubar's foreground color and wash the badge out.
+#[cfg(target_os = "macos")]
+static BADGE_ICON_BYTES: OnceLock<Vec<u8>> = OnceLock::new();
+
+// Caches the last unread state we pushed to the tray. `set_icon` in Tauri v2
+// resets icon_as_template, and the re-apply is visible as a small flicker,
+// so we only call into the tray when the state actually changes.
+#[cfg(target_os = "macos")]
+static PREV_UNREAD: OnceLock<Mutex<Option<bool>>> = OnceLock::new();
+
+/// Overlay a red filled circle in the upper-right corner of the base PNG
+/// and re-encode. Used only on macOS: paired with `set_icon_as_template(false)`
+/// so the red renders as red regardless of menubar dark/light mode. The
+/// original silhouette is preserved — the badge may overlap it slightly at
+/// the edge, which reads like a mac-native notification dot.
+#[cfg(target_os = "macos")]
+fn render_badged_icon_png(base_bytes: &[u8]) -> image::ImageResult<Vec<u8>> {
+    let mut img = image::load_from_memory(base_bytes)?.to_rgba8();
+    let (w, h) = img.dimensions();
+    let cx = (w * 5 / 6) as i32;
+    let cy = (h / 6) as i32;
+    let badge_r = (w / 6) as i32;
+    let red = image::Rgba([0xE0, 0x1B, 0x24, 0xFF]);
+    let y0 = (cy - badge_r).max(0);
+    let y1 = (cy + badge_r + 1).min(h as i32);
+    let x0 = (cx - badge_r).max(0);
+    let x1 = (cx + badge_r + 1).min(w as i32);
+    for y in y0..y1 {
+        for x in x0..x1 {
+            let dx = x - cx;
+            let dy = y - cy;
+            if dx * dx + dy * dy <= badge_r * badge_r {
+                img.put_pixel(x as u32, y as u32, red);
+            }
+        }
+    }
+    let mut buf = Vec::new();
+    img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)?;
+    Ok(buf)
+}
+
 #[tauri::command]
 pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
     let Some(tray) = app.tray_by_id(TRAY_ID) else {
         return;
     };
 
-    // macOS menubar: adjacent text next to the icon.
+    // macOS menubar: adjacent text next to the icon, plus a dynamic icon
+    // variant that carries the unread indicator as a red dot.
     #[cfg(target_os = "macos")]
     {
         let title = if count == 0 {
             None
-        } else if has_unread {
-            // Red-dot emoji prefix stands in for colored text: macOS tray
-            // titles are plain strings (no NSAttributedString via tauri),
-            // so we flag "unread exists" with a visible glyph instead.
-            Some(format!(" 🔴 {count}"))
         } else {
             Some(format!(" {count}"))
         };
         eprintln!("[eir] set_tray_badge count={count} has_unread={has_unread} title={title:?}");
         let _ = tray.set_title(title);
+
+        let prev = PREV_UNREAD.get_or_init(|| Mutex::new(None));
+        let mut prev_guard = prev.lock().expect("PREV_UNREAD poisoned");
+        if *prev_guard != Some(has_unread) {
+            // Order matters: set_icon resets icon_as_template in Tauri v2
+            // (see tauri-apps/tauri#6527), so we always re-apply the template
+            // flag after swapping the icon.
+            if has_unread {
+                if let Some(bytes) = BADGE_ICON_BYTES.get() {
+                    if let Ok(image) = Image::from_bytes(bytes) {
+                        let _ = tray.set_icon(Some(image));
+                    }
+                }
+                let _ = tray.set_icon_as_template(false);
+            } else {
+                if let Ok(image) = Image::from_bytes(TRAY_ICON_BYTES) {
+                    let _ = tray.set_icon(Some(image));
+                }
+                let _ = tray.set_icon_as_template(true);
+            }
+            *prev_guard = Some(has_unread);
+        }
     }
 
     // Windows / Linux: no adjacent-text slot on the tray icon, so surface the
@@ -223,6 +286,19 @@ fn position_near_tray(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
 pub fn setup(app: &App) -> tauri::Result<()> {
     let quit_item = MenuItem::with_id(app, "quit", "Quit eir", true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&quit_item])?;
+
+    // Synthesise the unread-badge variant once at startup. If rendering fails
+    // we fall back to the plain icon — the visual cue is lost but the tray
+    // still functions.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = BADGE_ICON_BYTES.set(render_badged_icon_png(TRAY_ICON_BYTES).unwrap_or_else(
+            |err| {
+                eprintln!("[eir] badge icon render failed: {err}");
+                TRAY_ICON_BYTES.to_vec()
+            },
+        ));
+    }
 
     let tray_icon = Image::from_bytes(TRAY_ICON_BYTES)?;
     let builder = TrayIconBuilder::with_id(TRAY_ID).icon(tray_icon);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -29,11 +29,11 @@ const TRAY_ID: &str = "main";
 #[cfg(target_os = "macos")]
 static BADGE_ICON_BYTES: OnceLock<Vec<u8>> = OnceLock::new();
 
-// Caches the last unread state we pushed to the tray. `set_icon` in Tauri v2
-// resets icon_as_template, and the re-apply is visible as a small flicker,
-// so we only call into the tray when the state actually changes.
+// Caches (count, has_unread) as last pushed to the tray. `set_icon` in Tauri
+// v2 resets icon_as_template, and the re-apply is visible as a small flicker,
+// so we only touch the tray when something actually changed.
 #[cfg(target_os = "macos")]
-static PREV_UNREAD: OnceLock<Mutex<Option<bool>>> = OnceLock::new();
+static PREV_TRAY: OnceLock<Mutex<Option<(u32, bool)>>> = OnceLock::new();
 
 /// Overlay a red filled circle in the upper-right corner of the base PNG
 /// and re-encode. Used only on macOS: paired with `set_icon_as_template(false)`
@@ -76,6 +76,14 @@ pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
     // variant that carries the unread indicator as a red dot.
     #[cfg(target_os = "macos")]
     {
+        let prev = PREV_TRAY.get_or_init(|| Mutex::new(None));
+        let mut prev_guard = prev.lock().expect("PREV_TRAY poisoned");
+        let next = (count, has_unread);
+        if *prev_guard == Some(next) {
+            return;
+        }
+        let prev_unread = prev_guard.map(|(_, u)| u);
+
         let title = if count == 0 {
             None
         } else {
@@ -84,27 +92,27 @@ pub fn set_tray_badge(count: u32, has_unread: bool, app: tauri::AppHandle) {
         eprintln!("[eir] set_tray_badge count={count} has_unread={has_unread} title={title:?}");
         let _ = tray.set_title(title);
 
-        let prev = PREV_UNREAD.get_or_init(|| Mutex::new(None));
-        let mut prev_guard = prev.lock().expect("PREV_UNREAD poisoned");
-        if *prev_guard != Some(has_unread) {
+        if prev_unread != Some(has_unread) {
             // Order matters: set_icon resets icon_as_template in Tauri v2
-            // (see tauri-apps/tauri#6527), so we always re-apply the template
-            // flag after swapping the icon.
-            if has_unread {
-                if let Some(bytes) = BADGE_ICON_BYTES.get() {
-                    if let Ok(image) = Image::from_bytes(bytes) {
+            // (see tauri-apps/tauri#6527), so re-apply the template flag
+            // after swapping the icon.
+            let icon_bytes: Option<&[u8]> = if has_unread {
+                BADGE_ICON_BYTES.get().map(Vec::as_slice)
+            } else {
+                Some(TRAY_ICON_BYTES)
+            };
+            if let Some(bytes) = icon_bytes {
+                match Image::from_bytes(bytes) {
+                    Ok(image) => {
                         let _ = tray.set_icon(Some(image));
                     }
+                    Err(err) => eprintln!("[eir] tray icon decode failed: {err}"),
                 }
-                let _ = tray.set_icon_as_template(false);
-            } else {
-                if let Ok(image) = Image::from_bytes(TRAY_ICON_BYTES) {
-                    let _ = tray.set_icon(Some(image));
-                }
-                let _ = tray.set_icon_as_template(true);
             }
-            *prev_guard = Some(has_unread);
+            let _ = tray.set_icon_as_template(!has_unread);
         }
+
+        *prev_guard = Some(next);
     }
 
     // Windows / Linux: no adjacent-text slot on the tray icon, so surface the

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -745,19 +745,22 @@
     }
   }
 
+  async function clearNotificationThreads(threadIds: Set<number>) {
+    if (threadIds.size === 0) return;
+    notifications = notifications.filter((n) => !threadIds.has(n.thread_id));
+    updateBadge();
+    await Promise.all(
+      [...threadIds].map((threadId) =>
+        invoke("mark_notification_read", { threadId }).catch(() => {}),
+      ),
+    );
+  }
+
   async function openItem(item: WatchedItem) {
     void openUrl(item.url);
     const matching = notificationsByKey.get(itemKey(item)) ?? [];
-    if (matching.length === 0) return;
-    const toClear = new Set(matching.map((n) => n.thread_id));
-    notifications = notifications.filter((n) => !toClear.has(n.thread_id));
-    updateBadge();
-    await Promise.all(
-      matching.map((n) =>
-        invoke("mark_notification_read", { threadId: n.thread_id }).catch(
-          () => {},
-        ),
-      ),
+    await clearNotificationThreads(
+      new Set(matching.map((n) => n.thread_id)),
     );
   }
 
@@ -777,13 +780,7 @@
       }),
     );
     if (!ok) return;
-    notifications = notifications.filter((n) => !threadIds.has(n.thread_id));
-    updateBadge();
-    await Promise.all(
-      [...threadIds].map((threadId) =>
-        invoke("mark_notification_read", { threadId }).catch(() => {}),
-      ),
-    );
+    await clearNotificationThreads(threadIds);
   }
 
   function onIntervalChange(value: number) {
@@ -881,10 +878,7 @@
   );
 
   const visibleUnreadCount = $derived(
-    visibleItems.reduce(
-      (acc, i) => acc + (notificationsByKey.has(itemKey(i)) ? 1 : 0),
-      0,
-    ),
+    visibleItems.filter((i) => notificationsByKey.has(itemKey(i))).length,
   );
 
   const groups = $derived(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1155,7 +1155,18 @@
           title="Mark {visibleUnreadCount} as read"
           aria-label="Mark all as read"
         >
-          ✓
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 7 17l-5-5" />
+            <path d="m22 10-7.5 7.5L13 16" />
+          </svg>
         </button>
       {/if}
       <button
@@ -1164,7 +1175,20 @@
         title="Settings"
         aria-label="Settings"
       >
-        ⚙
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+          />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
       </button>
       <button class="signout" onclick={signOut}>Sign out</button>
     </header>
@@ -1557,8 +1581,10 @@
   }
 
   .icon-btn {
-    padding: 0 10px;
-    font-size: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 10px;
     border: none;
     border-radius: 6px;
     background: rgba(0, 0, 0, 0.05);
@@ -1569,6 +1595,12 @@
 
   .icon-btn:hover {
     background: rgba(0, 0, 0, 0.1);
+  }
+
+  .icon-btn svg {
+    width: 16px;
+    height: 16px;
+    display: block;
   }
 
   .hint {
@@ -1634,11 +1666,12 @@
   }
 
   .signout {
-    background: none;
-    color: rgba(27, 27, 31, 0.6);
+    background: rgba(0, 0, 0, 0.05);
+    color: inherit;
   }
 
   .signout:hover {
+    background: rgba(209, 36, 47, 0.12);
     color: #d1242f;
   }
 
@@ -2050,12 +2083,19 @@
     .meta,
     .hint,
     .waiting,
-    .signout,
     .group-header,
     .back,
     .setting-hint,
     .setting-hint-inline {
       color: rgba(236, 236, 239, 0.6);
+    }
+    .signout {
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+    }
+    .signout:hover {
+      background: rgba(248, 81, 73, 0.2);
+      color: #ff7b72;
     }
     .setting-hint-inline.update-available {
       color: #3fb950;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -220,8 +220,8 @@
   }
 
   async function loadItems({ silent = false }: { silent?: boolean } = {}) {
+    loading = true;
     if (!silent) {
-      loading = true;
       error = null;
     }
     try {
@@ -310,7 +310,7 @@
         error = msg;
       }
     } finally {
-      if (!silent) loading = false;
+      loading = false;
     }
   }
 
@@ -929,6 +929,7 @@
 </script>
 
 <main class="container">
+  <div class="progress-bar" class:visible={loading} aria-hidden="true"></div>
   {#if showingSettings}
     <section class="settings">
       <div class="settings-header">
@@ -1202,7 +1203,7 @@
         <p>Nothing here.</p>
       </section>
     {:else}
-      <ul class="list">
+      <ul class="list" class:dim={loading}>
         {#each groups as group (group.repo)}
           <li class="group">
             <div class="group-header">
@@ -1379,11 +1380,53 @@
   }
 
   .container {
+    position: relative;
     display: flex;
     flex-direction: column;
     height: 100vh;
     padding: 16px;
     box-sizing: border-box;
+  }
+
+  .progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    overflow: hidden;
+    opacity: 0;
+    transition: opacity 0.15s;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .progress-bar.visible {
+    opacity: 1;
+  }
+
+  .progress-bar::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 30%;
+    background: #0969da;
+    animation: progress-slide 1.1s ease-in-out infinite;
+  }
+
+  @keyframes progress-slide {
+    0% {
+      left: -30%;
+    }
+    100% {
+      left: 100%;
+    }
+  }
+
+  .list.dim {
+    opacity: 0.45;
+    transition: opacity 0.15s;
   }
 
   .toolbar {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -761,6 +761,31 @@
     );
   }
 
+  async function markAllVisibleAsRead() {
+    const threadIds = new Set<number>();
+    for (const item of visibleItems) {
+      const matching = notificationsByKey.get(itemKey(item));
+      if (!matching) continue;
+      for (const n of matching) threadIds.add(n.thread_id);
+    }
+    if (threadIds.size === 0) return;
+    const ok = await withPinnedWindow(() =>
+      ask(`Mark ${threadIds.size} notification(s) as read?`, {
+        title: "eir",
+        kind: "info",
+        okLabel: "Mark as read",
+      }),
+    );
+    if (!ok) return;
+    notifications = notifications.filter((n) => !threadIds.has(n.thread_id));
+    updateBadge();
+    await Promise.all(
+      [...threadIds].map((threadId) =>
+        invoke("mark_notification_read", { threadId }).catch(() => {}),
+      ),
+    );
+  }
+
   function onIntervalChange(value: number) {
     refreshMs = value;
     localStorage.setItem(INTERVAL_KEY, String(value));
@@ -853,6 +878,13 @@
       excludedRepos,
       hiddenItems,
     }),
+  );
+
+  const visibleUnreadCount = $derived(
+    visibleItems.reduce(
+      (acc, i) => acc + (notificationsByKey.has(itemKey(i)) ? 1 : 0),
+      0,
+    ),
   );
 
   const groups = $derived(
@@ -1116,6 +1148,16 @@
       <button class="refresh" onclick={() => loadItems()} disabled={loading}>
         {loading ? "Refreshing…" : "Refresh"}
       </button>
+      {#if visibleUnreadCount > 0}
+        <button
+          class="icon-btn"
+          onclick={markAllVisibleAsRead}
+          title="Mark {visibleUnreadCount} as read"
+          aria-label="Mark all as read"
+        >
+          ✓
+        </button>
+      {/if}
       <button
         class="icon-btn"
         onclick={() => (showingSettings = true)}


### PR DESCRIPTION
## Summary

- **Mark all as read**: new ✓ toolbar button (shown only when the current tab has unread). Confirms with a native dialog, then batch-clears matching notification threads and fires `mark_notification_read` in parallel.
- **Review tab semantics**: now unions `review-requested:@me` with `reviewed-by:@me` so PRs stay visible after you've commented/approved — the tab no longer "empties itself" mid-review.
- **Dynamic tray badge (macOS)**: drops the 🔴 emoji prefix. A red-dot variant of the tray icon is synthesised at startup (upper-right overlay on the template silhouette) and swapped in via `tray.set_icon()` whenever there are unread items. Template mode is toggled off while the badge is active so the red actually renders red; toggled back on when unread clears so the icon resumes light/dark auto-tinting. State change is gated via `PREV_TRAY` so title + icon IPC is skipped on the 60s refresh when nothing changed.
- **Toolbar polish**: replaced the ⚙ / ✓ emoji with lucide SVGs (currentColor-stroked) so icon sizing is independent of font metrics; gave `Sign out` a filled button background so it matches visually.
- **Loading indicator**: `loadItems` now flips the loading flag on silent refreshes too. A 2px indeterminate progress bar fades in at the top of the popup and the item list dims to `opacity: 0.45` while fetching, so both manual and 60s auto-refresh give the same visual feedback.

## Test plan

- [ ] `cargo check && cargo clippy --all-targets -- -D warnings && cargo test --lib && cargo fmt --check` (all green)
- [ ] `pnpm check && pnpm test` (all green)
- [ ] `pnpm tauri dev` — verify:
  - [ ] Toolbar: Refresh / ✓ (when unread) / ⚙ / Sign out are visually aligned
  - [ ] ✓ confirms via native dialog, clears both the list's unread markers and the tray badge
  - [ ] Review tab shows PRs you've approved/commented on (not just pending review requests)
  - [ ] Tray: unread → silhouette with red dot at upper-right; no unread → monochrome silhouette with auto light/dark tint; flipping unread on/off doesn't flicker on every 60s refresh
  - [ ] Progress bar appears at the top during manual Refresh and during 60s auto-refresh; list dims while fetching and returns to full opacity on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)