### PR TITLE
fix: unscope scrollbar CSS so WebKit matches in production builds

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1349,32 +1349,32 @@
     padding: 0;
   }
 
-  .list,
-  .settings {
+  :global(.list),
+  :global(.settings) {
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
   }
 
-  .list::-webkit-scrollbar,
-  .settings::-webkit-scrollbar {
+  :global(.list::-webkit-scrollbar),
+  :global(.settings::-webkit-scrollbar) {
     width: 8px;
   }
 
-  .list::-webkit-scrollbar-track,
-  .settings::-webkit-scrollbar-track {
+  :global(.list::-webkit-scrollbar-track),
+  :global(.settings::-webkit-scrollbar-track) {
     background: transparent;
   }
 
-  .list::-webkit-scrollbar-thumb,
-  .settings::-webkit-scrollbar-thumb {
+  :global(.list::-webkit-scrollbar-thumb),
+  :global(.settings::-webkit-scrollbar-thumb) {
     background-color: rgba(0, 0, 0, 0.2);
     border-radius: 4px;
     border: 2px solid transparent;
     background-clip: content-box;
   }
 
-  .list::-webkit-scrollbar-thumb:hover,
-  .settings::-webkit-scrollbar-thumb:hover {
+  :global(.list::-webkit-scrollbar-thumb:hover),
+  :global(.settings::-webkit-scrollbar-thumb:hover) {
     background-color: rgba(0, 0, 0, 0.35);
     background-clip: content-box;
   }
@@ -2230,16 +2230,16 @@
       background: rgba(139, 148, 158, 0.18);
       border-color: rgba(139, 148, 158, 0.5);
     }
-    .list,
-    .settings {
+    :global(.list),
+    :global(.settings) {
       scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
     }
-    .list::-webkit-scrollbar-thumb,
-    .settings::-webkit-scrollbar-thumb {
+    :global(.list::-webkit-scrollbar-thumb),
+    :global(.settings::-webkit-scrollbar-thumb) {
       background-color: rgba(255, 255, 255, 0.18);
     }
-    .list::-webkit-scrollbar-thumb:hover,
-    .settings::-webkit-scrollbar-thumb:hover {
+    :global(.list::-webkit-scrollbar-thumb:hover),
+    :global(.settings::-webkit-scrollbar-thumb:hover) {
       background-color: rgba(255, 255, 255, 0.32);
     }
   }


### PR DESCRIPTION
## Summary
- Popup の `.list` / `.settings` scrollbar の custom CSS が、`pnpm tauri dev` では効いていたのに DMG インストール版では効かず macOS ネイティブの太い白スクロールバーが出ていた問題を修正。
- 原因は Svelte の scoped CSS が `.list::-webkit-scrollbar` を `.list.svelte-HASH::-webkit-scrollbar` に書き換え、WKWebView がこの compound selector にマッチしてくれないこと（[tauri#6067](https://github.com/tauri-apps/tauri/issues/6067) / [Svelte scoped styles docs](https://svelte.dev/docs/svelte/scoped-styles) で既知のパターン）。dev 側は HMR の注入タイミングで偶然効いていたのみ。
- `::-webkit-scrollbar*` 系のセレクタを `:global(...)` でラップし、hash class を外して production でも適用されるようにした。ライト/ダーク両方、`.list` と `.settings` 両方に適用。

## Test plan
- [ ] `pnpm tauri dev` でこれまで通り scrollbar が細い theme-aware スタイルになっていること
- [ ] `pnpm tauri build` で生成した `.dmg` からインストールし直し、popup のリストを overflow させた時に細いカスタム scrollbar が出ること（以前は太い白のネイティブが出ていた）
- [ ] dark/light 両モードで色が正しく切り替わること
- [ ] build 後の CSS (`build/_app/immutable/assets/2.*.css`) で scrollbar セレクタから `.svelte-HASH` が消えていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)