### PR TITLE
fix: surface test-notification errors in Settings view

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -528,6 +528,7 @@
   }
 
   async function sendTestNotification() {
+    error = null;
     if (!(await ensureNotificationPermission())) {
       error =
         "OS notification permission not granted. Check System Settings → Notifications → eir.";
@@ -535,7 +536,8 @@
     }
     showNotification(
       "eir test notification",
-      "If you see this, notifications are working.",
+      "Click to open the eir repo.",
+      "https://github.com/yagince/eir",
     );
   }
 
@@ -1113,6 +1115,9 @@
           <kbd>Cmd</kbd>+<kbd>,</kbd> opens settings ·
           <kbd>Backspace</kbd> goes back.
         </p>
+        {#if error}
+          <p class="error">{error}</p>
+        {/if}
       </div>
     </section>
   {:else if phase === "idle"}


### PR DESCRIPTION
## Summary
- `sendTestNotification()` was silently failing when notification permission was denied — the `error` state it set was only rendered inside the list view, which the Settings panel completely overlays. Clicking Send did nothing visible.
- Now the error renders at the bottom of the Settings body, and stale errors are cleared at the start of each Send attempt.
- Also pass `https://github.com/yagince/eir` to the test notification so it goes through the same `showNotification(title, body, url)` path as real item-change notifications.

## Background — why clicking the notification still doesn't open the URL
Investigated: the `.onclick` path in `showNotification` is effectively dead code on macOS.
- `tauri-plugin-notification` overrides `window.Notification` with a plain function that doesn't return a real Notification instance, so `n.onclick = …` is an orphan property assignment.
- The desktop backend is `notify-rust`, which doesn't emit click events on macOS ([tauri-apps/plugins-workspace#2150](https://github.com/tauri-apps/plugins-workspace/issues/2150), open since 2022).
- Proper fix would be migrating to the [`user-notify`](https://github.com/Simon-Laux/user-notify) crate (native `UNUserNotificationCenter` delegate), but that's a significant refactor and Windows support needs a custom URL-scheme deep link. Explicitly out of scope here.

This PR just makes the permission-denied case visible to the user. The click-to-open-URL story stays broken for now but is at least acknowledged.

## Test plan
- [ ] Open Settings → click **Send** with notification permission granted → notification appears with title "eir test notification" and body "Click to open the eir repo."
- [ ] Revoke notification permission in System Settings → Notifications → eir, then click **Send** → red error message appears at the bottom of the Settings panel
- [ ] Cause an unrelated error (e.g. load failure) then open Settings → the stale error should clear as soon as you click Send again

🤖 Generated with [Claude Code](https://claude.com/claude-code)