### PR TITLE
docs+ci: OS-controlled notification duration note; skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,15 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Named after Eir, the Norse goddess of healing. The icon combines a watching eye 
 - **Grouped list** — PRs and Issues grouped by repository with sticky headers and per-repo unread counts
 - **Filter tabs** — All / Mine / Review Requests / Mentions / Hidden, backed by different GitHub search queries
 - **Auto-refresh** — silent background polling every 30s–5min (configurable)
-- **Native notifications** — desktop notifications when a new PR or Issue first appears
+- **Native notifications** — desktop notifications when a new PR or Issue first appears (banner duration is set by the OS; on macOS, switch the style from *Banners* to *Alerts* under System Settings → Notifications → eir to keep them on screen until dismissed)
 - **Unread tracking** — macOS tray badge shows the unread count; Windows/Linux show it in the hover tooltip
 - **Global shortcut** — `Ctrl+Shift+E` toggles the popup from anywhere
 - **Light/dark aware** — template-mode tray icon on macOS and `prefers-color-scheme` styling everywhere


### PR DESCRIPTION
## Summary
- README の `Native notifications` 行に、バナー表示時間は OS 側の設定で、macOS なら *Banners* → *Alerts* に切り替えると手動で閉じるまで残る、という注記を追加
- `.github/workflows/ci.yml` の `push` / `pull_request` トリガーに `paths-ignore` を追加し、`**.md` / `docs/**` / `assets/**` のみの変更で CI ランナーが起動しないように

## なぜ
通知の表示時間を伸ばしたい要望があったが、Web Notification API / tauri-plugin-notification / mac-notification-sys / UNUserNotificationCenter いずれも公開 API としてバナー時間を指定できないため、コード側では解決不能。README で利用者をセルフサービス解決に誘導するに留める。

CI スキップは、今回のような docs-only PR で frontend + rust×3 の 4 ランナーを回すのを避けるため。`ci.yml` 自体は paths-ignore の対象外なので、CI 設定変更は今後も検証される。

## Test plan
- [ ] GitHub 上で README のリスト構造が崩れずレンダリングされることを確認
- [ ] この PR のあと、README のみを変更する PR を作って CI が起動しないことを確認（次回以降）

🤖 Generated with [Claude Code](https://claude.com/claude-code)