### PR TITLE
style: widen gap between list items

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1807,7 +1807,7 @@
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 8px;
   }
 
   .item-row {


### PR DESCRIPTION
## Summary
- リスト項目間の `gap` を 2px → 8px に拡張して、区切りを視認しやすくした。

## Test plan
- [ ] `pnpm tauri dev` でポップアップを開き、グループ内のアイテム同士の余白が広がっていることを確認