### PR TITLE
feat: export/import settings as JSON

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod github;
+mod settings_io;
 mod shortcut;
 mod tray;
 
@@ -54,6 +55,8 @@ pub fn run() {
             tray::set_tray_badge,
             shortcut::get_toggle_shortcut,
             shortcut::set_toggle_shortcut,
+            settings_io::write_text_file,
+            settings_io::read_text_file,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/settings_io.rs
+++ b/src-tauri/src/settings_io.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+#[tauri::command]
+pub fn write_text_file(path: String, contents: String) -> Result<String, String> {
+    let p = PathBuf::from(&path);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&p, contents).map_err(|e| e.to_string())?;
+    Ok(p.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+pub fn read_text_file(path: String) -> Result<String, String> {
+    std::fs::read_to_string(PathBuf::from(&path)).map_err(|e| e.to_string())
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   } from "@tauri-apps/plugin-notification";
   import { check as checkForUpdate, Update } from "@tauri-apps/plugin-updater";
   import { relaunch } from "@tauri-apps/plugin-process";
-  import { ask, message } from "@tauri-apps/plugin-dialog";
+  import { ask, message, open, save } from "@tauri-apps/plugin-dialog";
   import {
     disable as disableAutostart,
     enable as enableAutostart,
@@ -106,6 +106,8 @@
   const watchedOrgs = new SvelteSet<string>(loadWatchedOrgs());
   let newExcludedRepo = $state("");
   let newWatchedOrg = $state("");
+  let settingsIoError = $state<string | null>(null);
+  let settingsIoNotice = $state<string | null>(null);
 
   let prevThreads = new Map<number, string>();
   let prevItems = new Map<number, WatchedItem>();
@@ -856,6 +858,151 @@
     await loadItems();
   }
 
+  const SETTINGS_EXPORT_VERSION = 1;
+
+  type SettingsExport = {
+    version: number;
+    refreshMs?: number;
+    notifyEnabled?: boolean;
+    excludedRepos?: string[];
+    watchedOrgs?: string[];
+    hiddenItems?: number[];
+    toggleShortcut?: string;
+  };
+
+  function buildSettingsExport(): SettingsExport {
+    return {
+      version: SETTINGS_EXPORT_VERSION,
+      refreshMs,
+      notifyEnabled,
+      excludedRepos: [...excludedRepos].sort(),
+      watchedOrgs: [...watchedOrgs].sort(),
+      hiddenItems: [...hiddenItems].sort((a, b) => a - b),
+      toggleShortcut,
+    };
+  }
+
+  async function exportSettings() {
+    settingsIoError = null;
+    settingsIoNotice = null;
+    await withPinnedWindow(async () => {
+      try {
+        const stamp = new Date().toISOString().slice(0, 10);
+        const path = await save({
+          title: "Export eir settings",
+          defaultPath: `eir-settings-${stamp}.json`,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!path) return;
+        const payload = JSON.stringify(buildSettingsExport(), null, 2);
+        const written = await invoke<string>("write_text_file", {
+          path,
+          contents: payload,
+        });
+        settingsIoNotice = `Saved to ${written}`;
+      } catch (err) {
+        settingsIoError = `Export failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    });
+  }
+
+  async function importSettings() {
+    settingsIoError = null;
+    settingsIoNotice = null;
+    await withPinnedWindow(async () => {
+      try {
+        const selected = await open({
+          title: "Import eir settings",
+          multiple: false,
+          directory: false,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!selected || typeof selected !== "string") return;
+        const text = await invoke<string>("read_text_file", { path: selected });
+        const parsed = JSON.parse(text) as unknown;
+        applyImportedSettings(parsed, selected);
+      } catch (err) {
+        settingsIoError = `Import failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    });
+  }
+
+  function applyImportedSettings(raw: unknown, sourcePath?: string) {
+    if (!raw || typeof raw !== "object") {
+      throw new Error("not a JSON object");
+    }
+    const data = raw as Partial<SettingsExport>;
+    if (data.version !== SETTINGS_EXPORT_VERSION) {
+      throw new Error(
+        `unsupported version: ${data.version ?? "missing"} (expected ${SETTINGS_EXPORT_VERSION})`,
+      );
+    }
+
+    const applied: string[] = [];
+
+    if (typeof data.refreshMs === "number" && data.refreshMs >= 5_000) {
+      onIntervalChange(data.refreshMs);
+      applied.push("refresh interval");
+    }
+
+    if (typeof data.notifyEnabled === "boolean") {
+      onNotifyChange(data.notifyEnabled);
+      applied.push("notifications");
+    }
+
+    if (Array.isArray(data.excludedRepos)) {
+      const next = data.excludedRepos.filter(
+        (r): r is string => typeof r === "string" && r.includes("/"),
+      );
+      excludedRepos.clear();
+      for (const r of next) excludedRepos.add(r);
+      persistExcludedRepos();
+      applied.push("excluded repos");
+    }
+
+    if (Array.isArray(data.watchedOrgs)) {
+      const next = data.watchedOrgs.filter(
+        (o): o is string => typeof o === "string" && o.length > 0,
+      );
+      watchedOrgs.clear();
+      for (const o of next) watchedOrgs.add(o);
+      persistWatchedOrgs();
+      applied.push("watched orgs");
+    }
+
+    if (Array.isArray(data.hiddenItems)) {
+      const next = data.hiddenItems.filter(
+        (n): n is number => typeof n === "number" && Number.isFinite(n),
+      );
+      hiddenItems.clear();
+      for (const n of next) hiddenItems.add(n);
+      persistHiddenItems();
+      applied.push("hidden items");
+    }
+
+    if (typeof data.toggleShortcut === "string" && data.toggleShortcut) {
+      void invoke("set_toggle_shortcut", { shortcut: data.toggleShortcut })
+        .then(() => {
+          toggleShortcut = data.toggleShortcut as string;
+        })
+        .catch((err) => {
+          console.warn("[eir] import: shortcut rejected:", err);
+        });
+      applied.push("toggle shortcut");
+    }
+
+    updateBadge();
+    // Re-fetch so excluded-repo/watched-org changes hit the server query.
+    void loadItems({ silent: true });
+
+    settingsIoError = null;
+    const suffix = sourcePath ? ` from ${sourcePath}` : "";
+    settingsIoNotice =
+      applied.length > 0
+        ? `Imported ${applied.join(", ")}${suffix}.`
+        : `Nothing to import${suffix}.`;
+  }
+
   const repoSuggestions = $derived(
     repoSuggestionsFrom(items, excludedRepos),
   );
@@ -1109,6 +1256,27 @@
             </datalist>
             <button class="secondary" onclick={addExcludedRepo}>Add</button>
           </div>
+        </div>
+
+        <div class="setting-section">
+          <span class="setting-label">Backup settings</span>
+          <p class="setting-hint">
+            Export your configuration (refresh interval, notifications,
+            watched orgs, excluded repos, hidden items, shortcut) as a JSON
+            file, or import a previously saved file to restore it.
+          </p>
+          <div class="setting-buttons">
+            <button class="secondary" onclick={exportSettings}>Export</button>
+            <button class="secondary" onclick={importSettings}>Import</button>
+          </div>
+          {#if settingsIoNotice}
+            <p class="setting-hint io-path" title={settingsIoNotice}>
+              {settingsIoNotice}
+            </p>
+          {/if}
+          {#if settingsIoError}
+            <p class="error">{settingsIoError}</p>
+          {/if}
         </div>
 
         <p class="setting-hint">
@@ -1569,6 +1737,16 @@
     gap: 6px;
     padding-top: 8px;
     border-top: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  .setting-buttons {
+    display: flex;
+    gap: 8px;
+  }
+
+  .setting-hint.io-path {
+    font-family: "SF Mono", Menlo, monospace;
+    word-break: break-all;
   }
 
   .excluded-list {


### PR DESCRIPTION
## Summary
- Settingsパネルに「Backup settings」セクションを追加。設定(refresh interval / notifications / watched orgs / excluded repos / hidden items / toggle shortcut)をJSONファイルにexport、同形式のJSONからimportできる
- Tauriの`dialog.save`/`dialog.open`でネイティブの保存/開くダイアログを使い、保存完了後・読み込み後に **絶対パスをUIに表示** する
- Rust側に汎用の`write_text_file` / `read_text_file`コマンドを追加(書き込み時は親ディレクトリを自動作成、書き込み先の絶対パスを返却)
- Auth tokenはセキュリティ上exportに含めない。`activeTab`は端末固有なので除外

## Notes for reviewer
- Schemaは`{ version: 1, ... }`で、importは`version !== 1`なら拒否。将来の後方互換のための足場
- Import時は各フィールドを型チェック(例: `refreshMs >= 5_000`、`excludedRepos`は`owner/repo`形式のみ)してから反映
- Shortcutだけは`set_toggle_shortcut`がRust側のバリデーションで失敗する可能性があるのでnon-blocking(他設定の反映は止めない)
- Import後は`excludedRepos`/`watchedOrgs`がサーバークエリに影響するため`loadItems({ silent: true })`で再取得

## Test plan
- [ ] `pnpm tauri dev` で起動
- [ ] Settings → Export → ダイアログで保存先選択 → 「Saved to /path/...」と表示される
- [ ] 保存されたJSONを別の場所からImport → 「Imported ... from /path/...」と表示され、設定が復元される
- [ ] 不正なJSON(version違い、壊れた形式)を指定してエラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)