### PR TITLE
fix: reset popup scroll on reopen instead of on hide

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -548,17 +548,18 @@
 
   onMount(async () => {
     window.addEventListener("keydown", handleGlobalKey);
+    // Reset list scroll on show, not on hide: a scroll-reset issued while
+    // the popup is hidden gets overridden by the webview's scroll
+    // restoration when it's shown again.
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     // When the popup is hidden (focus loss or tray re-click), Settings is
-    // treated as transient: reopening should land back on the list scrolled
-    // to the top with the first item selected, so a fresh open feels like a
-    // fresh glance.
+    // treated as transient: reopening should land back on the list with
+    // the first item selected, so a fresh open feels like a fresh glance.
     void listen("popup-hidden", () => {
       showingSettings = false;
       // Clear selection so the $effect picks flatItems[0] on next render;
       // this also snaps keyboard nav back to the top.
       selectedId = null;
-      const list = document.querySelector<HTMLElement>(".list");
-      if (list) list.scrollTop = 0;
     }).then((fn) => {
       unlistenPopupHidden = fn;
     });
@@ -587,9 +588,16 @@
   onDestroy(() => {
     stopRefresh();
     window.removeEventListener("keydown", handleGlobalKey);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
     unlistenPopupHidden?.();
     unlistenPopupHidden = null;
   });
+
+  function handleVisibilityChange() {
+    if (document.visibilityState !== "visible") return;
+    const list = document.querySelector<HTMLElement>(".list");
+    if (list) list.scrollTop = 0;
+  }
 
   function formatShortcut(e: KeyboardEvent): string | null {
     if (["Control", "Shift", "Alt", "Meta"].includes(e.key)) return null;


### PR DESCRIPTION
## Summary
- Scrolling down in the list, closing the popup, and reopening it used to leave the view scrolled mid-list — the user had to manually scroll back to the top.
- The existing `popup-hidden` handler set `scrollTop = 0`, but the webview restores its scroll state on show, clobbering that reset.
- Moved the reset to a `visibilitychange` listener so it runs after the webview's restoration, guaranteeing a top-of-list landing on every reopen.

## Test plan
- [ ] Open the popup, scroll partway down the list.
- [ ] Close the popup via tray click — verify it hides.
- [ ] Reopen via tray click — list is scrolled to the top.
- [ ] Repeat via global shortcut (Ctrl+Shift+E) and via focus-loss hide.
- [ ] Open Settings, close popup, reopen — still lands on list (Settings reset still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)