### PR TITLE
Add left/right arrow keys to switch tabs

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -496,6 +496,14 @@
           moveSelection(-1);
           e.preventDefault();
           return;
+        case "ArrowLeft":
+          moveTab(-1);
+          e.preventDefault();
+          return;
+        case "ArrowRight":
+          moveTab(1);
+          e.preventDefault();
+          return;
         case "Enter":
           openSelected();
           e.preventDefault();
@@ -905,6 +913,13 @@
       );
       el?.scrollIntoView({ block: "nearest" });
     });
+  }
+
+  function moveTab(delta: number) {
+    const currentIdx = TABS.findIndex((t) => t.id === activeTab);
+    if (currentIdx < 0) return;
+    const nextIdx = (currentIdx + delta + TABS.length) % TABS.length;
+    void switchTab(TABS[nextIdx].id);
   }
 
   function openSelected() {


### PR DESCRIPTION
## Summary
- 左右矢印キーでタブバー (All / Mine / Review / Mentions / Hidden) を循環的に切り替えられるようにしました
- 上下矢印と同じく入力系要素 (INPUT / TEXTAREA / SELECT) では無視されます
- 実装は `handleGlobalKey` に `ArrowLeft` / `ArrowRight` の分岐を追加し、新しい `moveTab(delta)` ヘルパーで `switchTab` を呼ぶだけのシンプルな構成です

## Test plan
- [ ] ポップアップでフォーカスがリスト側にある状態で `←` / `→` を押してタブが切り替わる
- [ ] `Hidden` で `→` を押すと `All` に戻る (循環)
- [ ] 設定画面の入力フィールドにフォーカス中は矢印キーがタブ切り替えを起こさない
- [ ] `↑` / `↓` での選択移動、`Enter` でのオープンがこれまで通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)