### PR TITLE
feat: pin items and incremental search in the list

### DIFF
--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -15,6 +15,7 @@
     groups: RepoGroup[];
     selectedId: number | null;
     notificationsByKey: Map<string, NotificationItem[]>;
+    pinnedItems: ReadonlySet<number>;
     tabs: { id: Tab; label: string }[];
     error: string | null;
     onRefresh: () => void;
@@ -25,6 +26,7 @@
     onOpenItem: (item: WatchedItem) => void;
     onHideItem: (id: number) => void;
     onUnhideItem: (id: number) => void;
+    onTogglePin: (id: number) => void;
   };
 
   const {
@@ -35,6 +37,7 @@
     groups,
     selectedId,
     notificationsByKey,
+    pinnedItems,
     tabs,
     error,
     onRefresh,
@@ -45,6 +48,7 @@
     onOpenItem,
     onHideItem,
     onUnhideItem,
+    onTogglePin,
   }: Props = $props();
 </script>
 
@@ -113,10 +117,26 @@
   </section>
 {:else}
   <ul class="list" class:dim={loading}>
-    {#each groups as group (group.repo)}
-      <li class="group">
-        <div class="group-header">
-          <span class="group-repo">{group.repo}</span>
+    {#each groups as group (group.kind === "pinned" ? "__pinned__" : group.repo)}
+      <li class="group" class:pinned={group.kind === "pinned"}>
+        <div class="group-header" class:pinned-header={group.kind === "pinned"}>
+          <span class="group-repo">
+            {#if group.kind === "pinned"}
+              <svg
+                class="group-pin-icon"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M16 4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v3.8l-2.4 2.4A2 2 0 0 0 5 11.6V13h6v8l1 1 1-1v-8h6v-1.4a2 2 0 0 0-.6-1.4L16 7.8z"
+                />
+              </svg>
+              Pinned
+            {:else}
+              {group.repo}
+            {/if}
+          </span>
           {#if group.unreadCount > 0}
             <span class="group-count">{group.unreadCount}</span>
           {/if}
@@ -224,14 +244,39 @@
                   ↩
                 </button>
               {:else}
-                <button
-                  class="row-action"
-                  onclick={() => onHideItem(item.id)}
-                  title="Hide"
-                  aria-label="Hide"
-                >
-                  ×
-                </button>
+                <div class="row-actions">
+                  <button
+                    class="row-action pin-btn"
+                    class:pinned={pinnedItems.has(item.id)}
+                    onclick={() => onTogglePin(item.id)}
+                    title={pinnedItems.has(item.id) ? "Unpin" : "Pin"}
+                    aria-label={pinnedItems.has(item.id) ? "Unpin" : "Pin"}
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill={pinnedItems.has(item.id)
+                        ? "currentColor"
+                        : "none"}
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M16 4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v3.8l-2.4 2.4A2 2 0 0 0 5 11.6V13h6v8l1 1 1-1v-8h6v-1.4a2 2 0 0 0-.6-1.4L16 7.8z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    class="row-action"
+                    onclick={() => onHideItem(item.id)}
+                    title="Hide"
+                    aria-label="Hide"
+                  >
+                    ×
+                  </button>
+                </div>
               {/if}
             </li>
           {/each}
@@ -342,10 +387,23 @@
     backdrop-filter: blur(8px);
   }
 
+  .pinned-header {
+    color: var(--accent);
+  }
+
   .group-repo {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .group-pin-icon {
+    width: 11px;
+    height: 11px;
+    flex-shrink: 0;
   }
 
   .group-count {
@@ -395,11 +453,46 @@
   .row-action {
     visibility: hidden;
     pointer-events: none;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .row-action:hover {
+    background: var(--hover-bg);
   }
 
   .item-row:hover .row-action {
     visibility: visible;
     pointer-events: auto;
+  }
+
+  .row-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+  }
+
+  .pin-btn svg {
+    width: 12px;
+    height: 12px;
+    display: block;
+  }
+
+  /* A pinned item keeps its pin button visible even when the row isn't
+     hovered — it's an "on/off" state indicator, not just an action. */
+  .pin-btn.pinned {
+    visibility: visible;
+    pointer-events: auto;
+    color: var(--accent);
   }
 
   .item:hover {

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -18,6 +18,8 @@
     pinnedItems: ReadonlySet<number>;
     tabs: { id: Tab; label: string }[];
     error: string | null;
+    searchQuery: string;
+    searchVisible: boolean;
     onRefresh: () => void;
     onMarkAllVisibleAsRead: () => void;
     onShowSettings: () => void;
@@ -27,9 +29,11 @@
     onHideItem: (id: number) => void;
     onUnhideItem: (id: number) => void;
     onTogglePin: (id: number) => void;
+    onClearSearch: () => void;
+    onCloseSearch: () => void;
   };
 
-  const {
+  let {
     loading,
     activeTab,
     visibleItemsCount,
@@ -40,6 +44,8 @@
     pinnedItems,
     tabs,
     error,
+    searchQuery = $bindable(),
+    searchVisible,
     onRefresh,
     onMarkAllVisibleAsRead,
     onShowSettings,
@@ -49,7 +55,21 @@
     onHideItem,
     onUnhideItem,
     onTogglePin,
+    onClearSearch,
+    onCloseSearch,
   }: Props = $props();
+
+  function onSearchKeyDown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      if (searchQuery !== "") {
+        onClearSearch();
+      } else {
+        onCloseSearch();
+      }
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }
 </script>
 
 <header class="toolbar">
@@ -111,9 +131,48 @@
     </button>
   {/each}
 </nav>
+{#if searchVisible || searchQuery !== ""}
+  <div class="search" class:active={searchQuery !== ""}>
+    <svg
+      class="search-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+    <input
+      class="search-input"
+      type="text"
+      placeholder="Search title, repo, author, #number · Esc to close"
+      aria-label="Search"
+      bind:value={searchQuery}
+      onkeydown={onSearchKeyDown}
+    />
+    {#if searchQuery !== ""}
+      <button
+        class="search-clear"
+        onclick={onClearSearch}
+        title="Clear search"
+        aria-label="Clear search"
+      >
+        ×
+      </button>
+    {/if}
+  </div>
+{/if}
 {#if visibleItemsCount === 0 && !loading}
   <section class="empty">
-    <p>Nothing here.</p>
+    {#if searchQuery !== ""}
+      <p>No matches for "{searchQuery}".</p>
+    {:else}
+      <p>Nothing here.</p>
+    {/if}
   </section>
 {:else}
   <ul class="list" class:dim={loading}>
@@ -332,6 +391,63 @@
     padding: 0 0 8px;
     border-bottom: 1px solid var(--border-subtle);
     margin-bottom: 8px;
+  }
+
+  .search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    margin-bottom: 6px;
+    background: var(--surface-2);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    transition: border-color 0.1s;
+  }
+
+  .search:focus-within,
+  .search.active {
+    border-color: var(--accent);
+  }
+
+  .search-icon {
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    color: var(--fg-muted);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    padding: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: inherit;
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  .search-input::placeholder {
+    color: var(--fg-muted);
+  }
+
+  .search-clear {
+    flex-shrink: 0;
+    padding: 0 4px;
+    font-size: 14px;
+    line-height: 1;
+    background: none;
+    border: none;
+    color: var(--fg-muted);
+    cursor: pointer;
+    border-radius: 3px;
+  }
+
+  .search-clear:hover {
+    background: var(--hover-bg);
+    color: inherit;
   }
 
   .tab {

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { WatchedItem } from "./types";
 import {
+  filterBySearch,
   filterVisible,
   groupByRepo,
   itemKey,
@@ -208,5 +209,66 @@ describe("repoSuggestionsFrom", () => {
     ];
     const out = repoSuggestionsFrom(items, new Set(["c/c"]));
     expect(out).toEqual(["a/a", "b/b"]);
+  });
+});
+
+describe("filterBySearch", () => {
+  const items = [
+    makeItem({
+      id: 1,
+      repo: "acme/web",
+      number: 42,
+      title: "Fix login redirect loop",
+      author: "alice",
+    }),
+    makeItem({
+      id: 2,
+      repo: "acme/api",
+      number: 7,
+      title: "Add rate limiting",
+      author: "bob",
+    }),
+    makeItem({
+      id: 3,
+      repo: "other/cli",
+      number: 123,
+      title: "Upgrade CLI deps",
+      author: "carol",
+    }),
+  ];
+
+  it("returns input untouched when query is blank", () => {
+    expect(filterBySearch(items, "")).toBe(items);
+    expect(filterBySearch(items, "   ")).toBe(items);
+  });
+
+  it("matches case-insensitively against title", () => {
+    const out = filterBySearch(items, "LOGIN");
+    expect(out.map((i) => i.id)).toEqual([1]);
+  });
+
+  it("matches against repo name", () => {
+    const out = filterBySearch(items, "acme");
+    expect(out.map((i) => i.id)).toEqual([1, 2]);
+  });
+
+  it("matches against author", () => {
+    const out = filterBySearch(items, "bob");
+    expect(out.map((i) => i.id)).toEqual([2]);
+  });
+
+  it("matches against #number and bare number", () => {
+    expect(filterBySearch(items, "#42").map((i) => i.id)).toEqual([1]);
+    expect(filterBySearch(items, "123").map((i) => i.id)).toEqual([3]);
+  });
+
+  it("AND-combines whitespace-separated tokens", () => {
+    const out = filterBySearch(items, "acme limit");
+    expect(out.map((i) => i.id)).toEqual([2]);
+  });
+
+  it("returns empty array when no item matches all tokens", () => {
+    const out = filterBySearch(items, "acme nothingmatches");
+    expect(out).toEqual([]);
   });
 });

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -130,6 +130,72 @@ describe("groupByRepo", () => {
     const groups = groupByRepo(items, (i) => unread.has(i.id));
     expect(groups[0].unreadCount).toBe(2);
   });
+
+  it("places pinned items in a dedicated top group and removes them from their repo group", () => {
+    const items = [
+      makeItem({
+        id: 1,
+        repo: "a/a",
+        number: 1,
+        updated_at: "2026-04-10T00:00:00Z",
+      }),
+      makeItem({
+        id: 2,
+        repo: "b/b",
+        number: 2,
+        updated_at: "2026-04-19T00:00:00Z",
+      }),
+      makeItem({
+        id: 3,
+        repo: "a/a",
+        number: 3,
+        updated_at: "2026-04-18T00:00:00Z",
+      }),
+    ];
+    const groups = groupByRepo(items, () => false, new Set([2]));
+    expect(groups[0].kind).toBe("pinned");
+    expect(groups[0].items.map((i) => i.id)).toEqual([2]);
+    // b/b's sole item moved into the pinned group, so b/b disappears.
+    const remaining = groups.slice(1);
+    expect(remaining.map((g) => g.repo)).toEqual(["a/a"]);
+    expect(remaining[0].items.map((i) => i.id)).toEqual([3, 1]);
+  });
+
+  it("sorts the pinned group by updated_at desc", () => {
+    const items = [
+      makeItem({
+        id: 1,
+        repo: "a/a",
+        number: 1,
+        updated_at: "2026-04-10T00:00:00Z",
+      }),
+      makeItem({
+        id: 2,
+        repo: "b/b",
+        number: 2,
+        updated_at: "2026-04-19T00:00:00Z",
+      }),
+    ];
+    const groups = groupByRepo(items, () => false, new Set([1, 2]));
+    expect(groups[0].kind).toBe("pinned");
+    expect(groups[0].items.map((i) => i.id)).toEqual([2, 1]);
+  });
+
+  it("omits the pinned group entirely when nothing is pinned", () => {
+    const items = [makeItem({ id: 1, repo: "a/a", number: 1 })];
+    const groups = groupByRepo(items, () => false, new Set());
+    expect(groups.some((g) => g.kind === "pinned")).toBe(false);
+  });
+
+  it("counts unread within the pinned group via predicate", () => {
+    const items = [
+      makeItem({ id: 1, repo: "a/a", number: 1 }),
+      makeItem({ id: 2, repo: "b/b", number: 2 }),
+    ];
+    const groups = groupByRepo(items, (i) => i.id === 1, new Set([1, 2]));
+    expect(groups[0].kind).toBe("pinned");
+    expect(groups[0].unreadCount).toBe(1);
+  });
 });
 
 describe("repoSuggestionsFrom", () => {

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -35,6 +35,32 @@ export function filterVisible(
   );
 }
 
+/// Case-insensitive whitespace-split AND match across the fields a human
+/// would scan: title, repo, author, and `#<number>`. Returns the input
+/// untouched when the query is blank so callers don't need a guard.
+export function filterBySearch(
+  items: WatchedItem[],
+  query: string,
+): WatchedItem[] {
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return items;
+  return items.filter((item) => {
+    const haystack = [
+      item.title,
+      item.repo,
+      item.author,
+      `#${item.number}`,
+      String(item.number),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return tokens.every((t) => haystack.includes(t));
+  });
+}
+
 export function groupByRepo(
   items: WatchedItem[],
   isUnread: (i: WatchedItem) => boolean,

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -38,9 +38,15 @@ export function filterVisible(
 export function groupByRepo(
   items: WatchedItem[],
   isUnread: (i: WatchedItem) => boolean,
+  pinnedIds: ReadonlySet<number> = new Set(),
 ): RepoGroup[] {
+  const pinned: WatchedItem[] = [];
   const byRepo = new Map<string, WatchedItem[]>();
   for (const item of items) {
+    if (pinnedIds.has(item.id)) {
+      pinned.push(item);
+      continue;
+    }
     const bucket = byRepo.get(item.repo);
     if (bucket) {
       bucket.push(item);
@@ -48,18 +54,30 @@ export function groupByRepo(
       byRepo.set(item.repo, [item]);
     }
   }
-  const result: RepoGroup[] = [];
+
+  const repoGroups: RepoGroup[] = [];
   for (const [repo, groupItems] of byRepo) {
     groupItems.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
-    result.push({
+    repoGroups.push({
       repo,
       items: groupItems,
       mostRecent: groupItems[0].updated_at,
       unreadCount: groupItems.filter(isUnread).length,
     });
   }
-  result.sort((a, b) => b.mostRecent.localeCompare(a.mostRecent));
-  return result;
+  repoGroups.sort((a, b) => b.mostRecent.localeCompare(a.mostRecent));
+
+  if (pinned.length === 0) return repoGroups;
+
+  pinned.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  const pinnedGroup: RepoGroup = {
+    repo: "Pinned",
+    items: pinned,
+    mostRecent: pinned[0].updated_at,
+    unreadCount: pinned.filter(isUnread).length,
+    kind: "pinned",
+  };
+  return [pinnedGroup, ...repoGroups];
 }
 
 export function repoSuggestionsFrom(

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -5,6 +5,7 @@ export const INTERVAL_KEY = "eir.refreshMs";
 export const NOTIFY_KEY = "eir.notifyEnabled";
 export const EXCLUDED_REPOS_KEY = "eir.excludedRepos";
 export const HIDDEN_ITEMS_KEY = "eir.hiddenItems";
+export const PINNED_ITEMS_KEY = "eir.pinnedItems";
 export const WATCHED_ORGS_KEY = "eir.watchedOrgs";
 export const THEME_KEY = "eir.theme";
 
@@ -81,6 +82,19 @@ export function loadHiddenItems(): number[] {
 
 export function persistHiddenItems(values: Iterable<number>): void {
   localStorage.setItem(HIDDEN_ITEMS_KEY, JSON.stringify([...values]));
+}
+
+export function loadPinnedItems(): number[] {
+  try {
+    const raw = localStorage.getItem(PINNED_ITEMS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function persistPinnedItems(values: Iterable<number>): void {
+  localStorage.setItem(PINNED_ITEMS_KEY, JSON.stringify([...values]));
 }
 
 export function loadWatchedOrgs(): string[] {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,4 +52,5 @@ export type RepoGroup = {
   items: WatchedItem[];
   mostRecent: string;
   unreadCount: number;
+  kind?: "pinned";
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import { onDestroy, onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import {
+    filterBySearch,
     filterVisible,
     groupByRepo,
     itemKey,
@@ -95,6 +96,8 @@
   let capturingShortcut = $state(false);
   let shortcutError = $state<string | null>(null);
   let selectedId = $state<number | null>(null);
+  let searchQuery = $state("");
+  let searchVisible = $state(false);
 
   // The notification plugin's sendNotification() just invokes
   // `new window.Notification(title, options)` under the hood and throws away
@@ -361,6 +364,9 @@
       showingSettings = false;
       // Clear selection so the $effect picks flatItems[0] on next render.
       selectedId = null;
+      // Search is transient — reopening shouldn't inherit a stale filter.
+      searchQuery = "";
+      searchVisible = false;
     }).then((fn) => {
       unlistenPopupHidden = fn;
     });
@@ -489,6 +495,20 @@
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      // "/" or Cmd/Ctrl+F reveals the search input and moves focus to it.
+      // `/` alone is only grabbed when no modifier is held — otherwise
+      // Shift+/ (which also produces "?") could hijack other shortcuts.
+      if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        openSearch();
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        openSearch();
+        return;
+      }
 
       switch (e.key) {
         case "ArrowDown":
@@ -888,11 +908,14 @@
   });
 
   const visibleItems = $derived(
-    filterVisible(items, {
-      tab: activeTab,
-      excludedRepos,
-      hiddenItems,
-    }),
+    filterBySearch(
+      filterVisible(items, {
+        tab: activeTab,
+        excludedRepos,
+        hiddenItems,
+      }),
+      searchQuery,
+    ),
   );
 
   const visibleUnreadCount = $derived(
@@ -954,6 +977,29 @@
     if (selectedId == null) return;
     const item = flatItems.find((i) => i.id === selectedId);
     if (item) void openItem(item);
+  }
+
+  function focusSearchInput() {
+    const el = document.querySelector<HTMLInputElement>(".search-input");
+    if (!el) return;
+    el.focus();
+    el.select();
+  }
+
+  function openSearch() {
+    // Reveal the bar, then focus after Svelte mounts the input on the next
+    // tick. Focusing in the same synchronous pass finds no element to grab.
+    searchVisible = true;
+    queueMicrotask(() => focusSearchInput());
+  }
+
+  function closeSearch() {
+    searchVisible = false;
+    searchQuery = "";
+  }
+
+  function clearSearch() {
+    searchQuery = "";
   }
 </script>
 
@@ -1043,6 +1089,8 @@
       {pinnedItems}
       tabs={TABS}
       {error}
+      {searchVisible}
+      bind:searchQuery
       onRefresh={triggerRefresh}
       onMarkAllVisibleAsRead={markAllVisibleAsRead}
       onShowSettings={() => (showingSettings = true)}
@@ -1052,6 +1100,8 @@
       onHideItem={hideItem}
       onUnhideItem={unhideItem}
       onTogglePin={togglePin}
+      onClearSearch={clearSearch}
+      onCloseSearch={closeSearch}
     />
   {/if}
 </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,7 @@
     loadHiddenItems,
     loadInterval,
     loadNotify,
+    loadPinnedItems,
     loadTab,
     loadTheme,
     loadWatchedOrgs,
@@ -35,6 +36,7 @@
     persistHiddenItems,
     persistInterval,
     persistNotify,
+    persistPinnedItems,
     persistTab,
     persistTheme,
     persistWatchedOrgs,
@@ -123,6 +125,7 @@
   let autostartEnabled = $state<boolean | null>(null);
   const excludedRepos = new SvelteSet<string>(loadExcludedRepos());
   const hiddenItems = new SvelteSet<number>(loadHiddenItems());
+  const pinnedItems = new SvelteSet<number>(loadPinnedItems());
   const watchedOrgs = new SvelteSet<string>(loadWatchedOrgs());
   let newExcludedRepo = $state("");
   let newWatchedOrg = $state("");
@@ -651,6 +654,15 @@
     void pushBackgroundConfig({ hiddenItems: [...hiddenItems] });
   }
 
+  function togglePin(id: number) {
+    if (pinnedItems.has(id)) {
+      pinnedItems.delete(id);
+    } else {
+      pinnedItems.add(id);
+    }
+    persistPinnedItems(pinnedItems);
+  }
+
   function addExcludedRepo() {
     const name = newExcludedRepo.trim();
     if (!name || !name.includes("/")) return;
@@ -704,6 +716,7 @@
     excludedRepos?: string[];
     watchedOrgs?: string[];
     hiddenItems?: number[];
+    pinnedItems?: number[];
     toggleShortcut?: string;
   };
 
@@ -716,6 +729,7 @@
       excludedRepos: [...excludedRepos].sort(),
       watchedOrgs: [...watchedOrgs].sort(),
       hiddenItems: [...hiddenItems].sort((a, b) => a - b),
+      pinnedItems: [...pinnedItems].sort((a, b) => a - b),
       toggleShortcut,
     };
   }
@@ -827,6 +841,16 @@
       applied.push("hidden items");
     }
 
+    if (Array.isArray(data.pinnedItems)) {
+      const next = data.pinnedItems.filter(
+        (n): n is number => typeof n === "number" && Number.isFinite(n),
+      );
+      pinnedItems.clear();
+      for (const n of next) pinnedItems.add(n);
+      persistPinnedItems(pinnedItems);
+      applied.push("pinned items");
+    }
+
     if (typeof data.toggleShortcut === "string" && data.toggleShortcut) {
       void invoke("set_toggle_shortcut", { shortcut: data.toggleShortcut })
         .then(() => {
@@ -876,7 +900,11 @@
   );
 
   const groups = $derived(
-    groupByRepo(visibleItems, (i) => notificationsByKey.has(itemKey(i))),
+    groupByRepo(
+      visibleItems,
+      (i) => notificationsByKey.has(itemKey(i)),
+      pinnedItems,
+    ),
   );
 
   // Flat item order matching the rendered list (repo-groups preserved), so
@@ -1012,6 +1040,7 @@
       {groups}
       {selectedId}
       {notificationsByKey}
+      {pinnedItems}
       tabs={TABS}
       {error}
       onRefresh={triggerRefresh}
@@ -1022,6 +1051,7 @@
       onOpenItem={openItem}
       onHideItem={hideItem}
       onUnhideItem={unhideItem}
+      onTogglePin={togglePin}
     />
   {/if}
 </main>


### PR DESCRIPTION
## Summary
- **Pin** (`095d32a`): a dedicated "Pinned" pseudo-group at the top of the list, populated from an `eir.pinnedItems` set in localStorage. Toggle via the per-row pin button (always visible when pinned, hover-only otherwise). Pins participate in Settings export/import.
- **Search** (`632ad8b`): Cmd+F or `/` reveals an incremental search bar between the tabs and the list. Case-insensitive whitespace-split AND matching against title, repo, author, and `#number`. The bar is hidden by default; Esc clears a pending query, a second Esc (or popup hide) dismisses the bar entirely. Search composes with the existing tab/hidden/excluded filters so keyboard navigation and "mark all visible as read" stay in sync with what's on screen.

## Why
Both are recurring asks for a PR/issue watcher: pin keeps high-priority items in view regardless of recency, and search short-circuits scrolling through 50+ items on a busy day.

## Test plan
- [x] `pnpm test` — 22/22 passed (11 new tests split between pin grouping and search filter)
- [x] `pnpm check` — 0 errors / 0 warnings
- [ ] Launch `pnpm tauri dev` and smoke-test:
  - Pin / unpin from a row; verify the Pinned group appears and the item leaves its repo group
  - Confirm pins survive a sign-out/sign-in cycle (localStorage) and round-trip through Settings → Export/Import
  - Open search with Cmd+F, confirm matching is case-insensitive and that "mark all visible as read" only covers filtered items
  - Esc clears, second Esc closes; closing the popup resets both

🤖 Generated with [Claude Code](https://claude.com/claude-code)