### PR TITLE
fix: stop auto-refreshing on popup re-show

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -426,9 +426,6 @@
     if (document.visibilityState !== "visible") return;
     const list = document.querySelector<HTMLElement>(".list");
     if (list) list.scrollTop = 0;
-    // Opening the popup is an implicit "what's new?" — the worker's interval
-    // fires at most every refreshMs, which can be minutes.
-    triggerRefresh();
   }
 
   function formatShortcut(e: KeyboardEvent): string | null {


### PR DESCRIPTION
## Summary

- Removed the implicit `triggerRefresh()` call from `handleVisibilityChange` in [src/routes/+page.svelte](src/routes/+page.svelte).
- Re-opening the popup no longer forces a fetch; refresh is now driven only by the manual refresh button or the background interval.

## Why

The auto-reload on every re-show became noisy — popup toggles happen frequently (tray click, global shortcut, focus loss recover), each one kicked off a round-trip to GitHub. The background worker's interval already surfaces new items, and the refresh button covers the explicit "check now" case.

## Test plan

- [ ] `pnpm check` passes (verified locally)
- [ ] Open/close the popup repeatedly → no network requests fired from the frontend side
- [ ] Manual refresh button still works
- [ ] Background interval still refreshes on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)