### PR TITLE
chore: extend release-eir skill to wait, write notes, and publish

### DIFF
--- a/.claude/skills/release-eir/SKILL.md
+++ b/.claude/skills/release-eir/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release-eir
-description: Cut a new release for the eir GitHub PR/Issue watcher. Use this skill whenever the user asks to release, cut a release, bump the version, tag a release, or publish a new build — including short phrases like "release v0.2.0", "bump to 0.3", "タグ打ってリリース", "新しいリリース出して". The skill bumps the version in all three manifest files, runs a pre-flight check, commits, tags `v<version>`, and pushes. The release workflow in `.github/workflows/release.yml` then builds the macOS bundle for both arm64 and x64 and attaches them to a draft GitHub Release.
+description: Cut a new release for the eir GitHub PR/Issue watcher end-to-end — bump the version, push the tag, wait for the release workflow to build all four platforms, attach auto-generated release notes, and publish the draft. Use this skill whenever the user asks to release, cut a release, bump the version, tag a release, or publish a new build — including short phrases like "release v0.2.0", "bump to 0.3", "タグ打ってリリース", "新しいリリース出して". The skill bumps the version in all three manifest files, runs a pre-flight check, commits, tags `v<version>`, pushes, watches `.github/workflows/release.yml` until the arm64 / x64 / linux / windows matrix finishes, fills the draft release body with GitHub's auto-generated "What's Changed" notes, and flips the draft to published.
 ---
 
 # Releasing eir
 
-Every release goes through the same short checklist: verify the tree is clean, bump the three version files, commit, tag, push. The release workflow (`.github/workflows/release.yml`) picks up the tag and builds artefacts — your job is to set up that tag correctly so the workflow has good inputs.
+Every release goes through the same arc: verify the tree is clean, bump the three version files, commit, tag, push, wait for the workflow to build all four platforms, attach the auto-generated release notes, and publish. The release workflow (`.github/workflows/release.yml`) fans out into a 4-way matrix (macOS arm64/x64, linux-x64, windows-x64) and uploads each bundle into a single pre-created draft release. Your job is to drive that draft all the way to "published" — don't stop at the tag push.
 
 ## Preconditions
 
@@ -116,43 +116,110 @@ git push origin v<version>
 
 Use a plain `chore: release vX.Y.Z` subject with no body — it keeps `git log --oneline` scannable. Both pushes are required; the release workflow only triggers on the tag push.
 
-## Verify
+## Wait for the release build
 
-After pushing, confirm the workflow kicked off and give the user links:
+The skill is not done when the tag is pushed — the draft release is created almost immediately by the `create-release` job, but it's an empty shell until the four matrix builds upload their bundles. You must wait and confirm success before touching the release body or flipping it out of draft. A "release" with only two of four platforms uploaded is worse than no release at all, because users silently pick up an incomplete set.
 
-```bash
-gh run list --workflow=release.yml --limit 1
-gh run watch           # optional — follow the active run
-```
+### 1. Grab the run id for the tag push
 
-Once the workflow finishes (typically 5–10 minutes per target; arm64 and x64 macOS run in parallel) the draft release lands at:
+`gh run list` can race the tag push by a second or two (Actions needs time to register the ref), so poll a few times rather than assuming the first call returns the right row. Match on `headBranch` because for a tag push GitHub exposes the tag name there — this avoids accidentally grabbing an older run of the same workflow:
 
 ```bash
-gh release view v<version> --web
+TAG=v<version>
+for i in 1 2 3 4 5 6; do
+  RUN_ID=$(gh run list --workflow=release.yml --limit 5 \
+    --json databaseId,headBranch,event \
+    --jq "map(select(.event==\"push\" and .headBranch==\"$TAG\"))[0].databaseId")
+  [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] && break
+  sleep 5
+done
+echo "Watching run $RUN_ID"
 ```
 
-Tell the user to review the draft release's artefacts and publish when ready. The release stays drafted until someone explicitly publishes, so a bad build can be deleted without affecting downstream consumers.
+### 2. Watch until the matrix is done
+
+```bash
+gh run watch "$RUN_ID" --exit-status --compact
+```
+
+`--exit-status` is what makes this usable in a script: the command returns non-zero if any matrix job fails, so the next step can short-circuit. Typical wall time is 8–15 minutes — the arm64/x64 macOS jobs run in parallel with linux and windows, and the slowest one gates everything.
+
+If `gh run watch` exits non-zero, **do not proceed to publish**. Dump the failure and hand control back to the user:
+
+```bash
+gh run view "$RUN_ID" --log-failed | tail -200
+gh release view "$TAG" --web   # so they can inspect the half-filled draft
+```
+
+At that point the right move is usually to delete the draft + tag (see "Recovering from a bad release"), fix the root cause on `main`, and rerun the whole skill with the same version number — the release was never visible, so reusing the number is fine.
+
+## Attach generated release notes
+
+GitHub's UI has a "Generate release notes" button that produces a `## What's Changed` block (list of merged PRs grouped by label, plus a contributors line and a compare link). The REST API exposes the same generator at `POST /repos/{owner}/{repo}/releases/generate-notes`, which is what we want here — it guarantees byte-for-byte parity with the UI button and doesn't require us to roll our own `git log` formatter.
+
+Generate against the just-pushed tag, using the prior `v*` tag as the comparison base so the notes only cover this release's window:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+# Second entry in a reverse-semver-sorted tag list = the previous release.
+# (First entry is the tag we just pushed.)
+PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | sed -n '2p')
+
+NOTES_FILE=$(mktemp -t eir-release-notes.XXXXXX.md)
+gh api "repos/$REPO/releases/generate-notes" \
+  -f "tag_name=$TAG" \
+  ${PREV_TAG:+-f "previous_tag_name=$PREV_TAG"} \
+  --jq .body > "$NOTES_FILE"
+```
+
+If this is the first-ever release (no previous `v*` tag), the `previous_tag_name` flag is simply omitted and GitHub falls back to "all commits since the repo was created" — the notes end up a bit noisy but still correct.
+
+Apply the notes to the draft:
+
+```bash
+gh release edit "$TAG" --notes-file "$NOTES_FILE"
+```
+
+Show the user the first ~30 lines of `$NOTES_FILE` so they can sanity-check the generated text before publish. A quick `head -30` is enough — the skill should surface content, not silently ship it.
+
+## Publish the release
+
+Flip the draft to published and explicitly mark it "Latest". `--latest` matters because GitHub's auto-detection sometimes keeps the previous release marked latest when a new one is marked prerelease-adjacent or when tag sort order is ambiguous; being explicit avoids the update channel (the in-app "Check for updates" flow reads `latest.json` from the release tagged "Latest") silently stalling on an older build.
+
+```bash
+gh release edit "$TAG" --draft=false --latest
+gh release view "$TAG" --web
+```
+
+Report the release URL to the user in your final message. Do not also tell them "please publish when ready" — publish already happened.
 
 ## Recovering from a bad release
 
-Only do this when the user explicitly asks. Tag deletion is destructive and visible to anyone who has pulled.
+Only do this when the user explicitly asks, or when `gh run watch --exit-status` in the "Wait for the release build" step returned non-zero and you need to roll back before retrying. Tag deletion is destructive and visible to anyone who has already fetched.
 
-Before pushing the tag:
+Before pushing the tag (tag is only local):
 
 ```bash
 git reset --hard origin/main
 git tag -d v<version>
 ```
 
-After the tag is already pushed but the release is broken:
+After the tag is pushed but the release has not been published yet (still a draft) — this is the common case when the workflow failed mid-matrix:
 
 ```bash
-gh release delete v<version>          # or delete via the web UI
-git push origin :v<version>           # remove the remote tag
-git tag -d v<version>                 # remove the local tag
+gh release delete v<version> --cleanup-tag --yes
 ```
 
-Then revert or amend the version commit and redo the release with a fresh version number. Avoid reusing a published version number — downstream caches will think they already have that release.
+`--cleanup-tag` deletes both the draft release and the remote tag in one call; then drop the local tag with `git tag -d v<version>`. You can safely **reuse the same version number** in the next attempt because the release was never published — no downstream cache has seen it.
+
+If the release was already published (draft → public) and then found broken:
+
+```bash
+gh release delete v<version> --cleanup-tag --yes
+git tag -d v<version>
+```
+
+But in this case do **not** reuse the version number. Bump to the next patch and redo — downstream updaters and package caches may have already fetched `latest.json` for the broken version and will refuse to re-download the same tag.
 
 ## Why three files
 


### PR DESCRIPTION
## Summary

Improves the `release-eir` skill so it drives a release end-to-end instead of stopping at the tag push.

- **Wait for the build**: polls `gh run list` for the tag's push event, then `gh run watch --exit-status --compact` so any matrix failure short-circuits before the draft gets published.
- **Auto-generated release notes**: fills the draft body via `POST /repos/.../releases/generate-notes` (the REST endpoint behind GitHub's "Generate release notes" button), with `previous_tag_name` = prior `v*` tag, falling back to repo history on the first release.
- **Publish**: `gh release edit $TAG --draft=false --latest` — `--latest` is explicit so the in-app updater's `latest.json` channel doesn't stall on an older release.
- **Recovering** rewritten around `gh release delete --cleanup-tag --yes`, with draft-vs-published branching on whether the version number is safe to reuse.

## Why

The old skill left publish as a manual step and left release notes empty — every release needed a human to babysit the draft page and write a body. The new flow matches the UI's "Generate release notes" byte-for-byte and gates publish on all four matrix builds (macOS arm64/x64, linux-x64, windows-x64) succeeding.

## Test plan

- [ ] Run `/release-eir` on the next real release and confirm: workflow is waited on, release notes appear filled, draft flips to public, `--latest` sticks.
- [ ] Simulate a matrix failure (e.g. break a build temporarily) and confirm the skill stops before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)