### PR TITLE
feat: add unread-only filter chip below the tab bar

### DIFF
--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -20,6 +20,7 @@
     error: string | null;
     searchQuery: string;
     searchVisible: boolean;
+    unreadOnly: boolean;
     onRefresh: () => void;
     onMarkAllVisibleAsRead: () => void;
     onShowSettings: () => void;
@@ -31,6 +32,7 @@
     onTogglePin: (id: number) => void;
     onClearSearch: () => void;
     onCloseSearch: () => void;
+    onToggleUnreadOnly: () => void;
   };
 
   let {
@@ -46,6 +48,7 @@
     error,
     searchQuery = $bindable(),
     searchVisible,
+    unreadOnly,
     onRefresh,
     onMarkAllVisibleAsRead,
     onShowSettings,
@@ -57,6 +60,7 @@
     onTogglePin,
     onClearSearch,
     onCloseSearch,
+    onToggleUnreadOnly,
   }: Props = $props();
 
   function onSearchKeyDown(e: KeyboardEvent) {
@@ -136,6 +140,21 @@
     </button>
   {/each}
 </nav>
+<div class="filters">
+  <button
+    class="filter-chip"
+    class:active={unreadOnly}
+    onclick={onToggleUnreadOnly}
+    aria-pressed={unreadOnly}
+    title={unreadOnly ? "Showing unread only — click to show all" : "Show only unread items"}
+  >
+    <span class="filter-dot" aria-hidden="true"></span>
+    <span class="filter-label">Unread only</span>
+    {#if unreadOnly}
+      <span class="filter-x" aria-hidden="true">×</span>
+    {/if}
+  </button>
+</div>
 {#if searchVisible || searchQuery !== ""}
   <div class="search" class:active={searchQuery !== ""}>
     <svg
@@ -175,6 +194,8 @@
   <section class="empty">
     {#if searchQuery !== ""}
       <p>No matches for "{searchQuery}".</p>
+    {:else if unreadOnly}
+      <p>No unread items.</p>
     {:else}
       <p>Nothing here.</p>
     {/if}
@@ -388,6 +409,56 @@
     width: 16px;
     height: 16px;
     display: block;
+  }
+
+  .filters {
+    display: flex;
+    gap: 6px;
+    padding: 0 0 8px;
+    margin-bottom: 4px;
+  }
+
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    font-size: 11px;
+    font-weight: 500;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: none;
+    color: var(--fg-muted);
+    cursor: pointer;
+    line-height: 1.5;
+  }
+
+  .filter-chip:hover {
+    background: var(--hover-bg);
+  }
+
+  .filter-chip.active {
+    border-color: var(--accent);
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+
+  .filter-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--fg-muted);
+    flex-shrink: 0;
+  }
+
+  .filter-chip.active .filter-dot {
+    background: var(--accent);
+  }
+
+  .filter-x {
+    font-size: 13px;
+    line-height: 1;
+    opacity: 0.8;
   }
 
   .tabs {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -8,6 +8,7 @@ export const HIDDEN_ITEMS_KEY = "eir.hiddenItems";
 export const PINNED_ITEMS_KEY = "eir.pinnedItems";
 export const WATCHED_ORGS_KEY = "eir.watchedOrgs";
 export const THEME_KEY = "eir.theme";
+export const UNREAD_ONLY_KEY = "eir.unreadOnly";
 
 export const DEFAULT_REFRESH_MS = 60_000;
 
@@ -108,4 +109,12 @@ export function loadWatchedOrgs(): string[] {
 
 export function persistWatchedOrgs(values: Iterable<string>): void {
   localStorage.setItem(WATCHED_ORGS_KEY, JSON.stringify([...values]));
+}
+
+export function loadUnreadOnly(): boolean {
+  return localStorage.getItem(UNREAD_ONLY_KEY) === "1";
+}
+
+export function persistUnreadOnly(enabled: boolean): void {
+  localStorage.setItem(UNREAD_ONLY_KEY, enabled ? "1" : "0");
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,7 @@
     loadPinnedItems,
     loadTab,
     loadTheme,
+    loadUnreadOnly,
     loadWatchedOrgs,
     persistExcludedRepos,
     persistHiddenItems,
@@ -40,6 +41,7 @@
     persistPinnedItems,
     persistTab,
     persistTheme,
+    persistUnreadOnly,
     persistWatchedOrgs,
     type Theme,
   } from "$lib/storage";
@@ -98,6 +100,7 @@
   let selectedId = $state<number | null>(null);
   let searchQuery = $state("");
   let searchVisible = $state(false);
+  let unreadOnly = $state<boolean>(loadUnreadOnly());
 
   // The notification plugin's sendNotification() just invokes
   // `new window.Notification(title, options)` under the hood and throws away
@@ -738,6 +741,11 @@
     await pushBackgroundConfig({ watchedOrgs: [...watchedOrgs] });
   }
 
+  function toggleUnreadOnly() {
+    unreadOnly = !unreadOnly;
+    persistUnreadOnly(unreadOnly);
+  }
+
   async function switchTab(tab: Tab) {
     if (tab === activeTab) return;
     activeTab = tab;
@@ -929,16 +937,18 @@
     return [...seen].sort();
   });
 
-  const visibleItems = $derived(
-    filterBySearch(
+  const visibleItems = $derived.by(() => {
+    const base = filterBySearch(
       filterVisible(items, {
         tab: activeTab,
         excludedRepos,
         hiddenItems,
       }),
       searchQuery,
-    ),
-  );
+    );
+    if (!unreadOnly) return base;
+    return base.filter((i) => notificationsByKey.has(itemKey(i)));
+  });
 
   const visibleUnreadCount = $derived(
     visibleItems.filter((i) => notificationsByKey.has(itemKey(i))).length,
@@ -1112,6 +1122,7 @@
       tabs={TABS}
       {error}
       {searchVisible}
+      {unreadOnly}
       bind:searchQuery
       onRefresh={triggerRefresh}
       onMarkAllVisibleAsRead={markAllVisibleAsRead}
@@ -1124,6 +1135,7 @@
       onTogglePin={togglePin}
       onClearSearch={clearSearch}
       onCloseSearch={closeSearch}
+      onToggleUnreadOnly={toggleUnreadOnly}
     />
   {/if}
 </main>


### PR DESCRIPTION
## Summary

- Add an "Unread only" toggle that narrows the visible list to items with active notifications, without adding another top-level tab.
- Surfaces as a labeled chip below the tab row (accent-colored + `×` when active, muted pill when off) so it reads as a toggleable filter rather than a status indicator or extra tab.
- Persists to `localStorage` under `eir.unreadOnly` so it survives popup hide/reopen and app restarts.

## Why

Tabs (`All / Mine / Review / Mentions / Hidden`) scope *what* the worker queries. An unread filter is orthogonal — you may want "unread, in Review" or "unread, across all". Making it a separate filter chip keeps the tab bar focused and leaves room for additional filter chips later (e.g. CI-failed only).

The first pass used a bare circle icon in the toolbar, which was ambiguous ("is that a status or a toggle?"). The chip uses an explicit text label and standard pill-with-× affordance so the meaning is obvious.

## Files touched

- [src/lib/storage.ts](https://github.com/yagince/eir/blob/claude/serene-black-b360ba/src/lib/storage.ts) — `UNREAD_ONLY_KEY` + `loadUnreadOnly` / `persistUnreadOnly`.
- [src/routes/+page.svelte](https://github.com/yagince/eir/blob/claude/serene-black-b360ba/src/routes/+page.svelte) — `unreadOnly` state wired through `visibleItems` via `notificationsByKey.has(...)`.
- [src/lib/components/ItemList.svelte](https://github.com/yagince/eir/blob/claude/serene-black-b360ba/src/lib/components/ItemList.svelte) — new filter-chip row, active-state styling, "No unread items." empty copy.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm test` passes (22/22)
- [ ] `pnpm tauri dev`: toggle the chip, confirm the list narrows to rows with the unread dot
- [ ] Chip state persists across popup hide/show and app relaunch
- [ ] Combined with tab switches (e.g. Review + Unread only) filters correctly
- [ ] Empty state shows "No unread items." when enabled and nothing is unread
- [ ] Verify rendering in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)