### PR TITLE
fix: keep top list item fully visible on ArrowUp

### DIFF
--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -622,6 +622,9 @@
     display: flex;
     align-items: stretch;
     gap: 2px;
+    /* scrollIntoView doesn't know about the sticky .group-header, so without
+       this margin ArrowUp to the top item leaves it tucked under the header. */
+    scroll-margin-top: 28px;
   }
 
   .item {


### PR DESCRIPTION
## Summary
- Pressing ArrowUp to the first list item left it half-hidden under the sticky repo/group header because `scrollIntoView({ block: "nearest" })` ignores sticky overlays.
- Added `scroll-margin-top: 28px` to `.item-row` so the browser scrolls past the sticky `.group-header` (~22–24px tall) and the selected item's top edge ends up flush below it.
- Also smooths arrow-key navigation onto the first item of groups deeper in the list, where the same overlap occurs.

## Test plan
- [ ] Open the popup, scroll the list down, press ArrowUp until the first item is selected — the whole first item (title + meta) should be visible, not just its bottom half.
- [ ] Walk ArrowDown / ArrowUp across group boundaries; first item of each group lands below the sticky header without being clipped.
- [ ] Home / PageUp behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)