### PR TITLE
feat: U shortcut for unread-only + declarative shortcut module + Settings arrow-nav

### DIFF
--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -146,7 +146,7 @@
     class:active={unreadOnly}
     onclick={onToggleUnreadOnly}
     aria-pressed={unreadOnly}
-    title={unreadOnly ? "Showing unread only — click to show all" : "Show only unread items"}
+    title={unreadOnly ? "Showing unread only — click or press U to show all" : "Show only unread items (U)"}
   >
     <span class="filter-dot" aria-hidden="true"></span>
     <span class="filter-label">Unread only</span>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import type { Update } from "@tauri-apps/plugin-updater";
   import type { Theme } from "$lib/storage";
+  import { isTextCaretTarget } from "$lib/shortcuts";
 
   type UpdateStatus =
     | { kind: "idle" }
@@ -87,11 +89,54 @@
     onExportSettings,
     onImportSettings,
   }: Props = $props();
+
+  let sectionEl: HTMLElement | undefined;
+  let backEl: HTMLButtonElement | undefined;
+
+  onMount(() => {
+    backEl?.focus();
+    window.addEventListener("keydown", handleArrowNav);
+    return () => window.removeEventListener("keydown", handleArrowNav);
+  });
+
+  function focusableItems(): HTMLElement[] {
+    if (!sectionEl) return [];
+    const els = sectionEl.querySelectorAll<
+      HTMLButtonElement | HTMLInputElement | HTMLSelectElement
+    >("button, select, input");
+    return Array.from(els).filter(
+      (el) => !el.disabled && el.offsetParent !== null,
+    );
+  }
+
+  function handleArrowNav(e: KeyboardEvent) {
+    if (capturingShortcut) return;
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    // Text fields use arrows to move the caret natively — don't hijack.
+    if (isTextCaretTarget(document.activeElement)) return;
+
+    const items = focusableItems();
+    if (items.length === 0) return;
+
+    const active = document.activeElement as HTMLElement | null;
+    const currentIdx = active ? items.indexOf(active) : -1;
+    const delta = e.key === "ArrowDown" ? 1 : -1;
+
+    let nextIdx: number;
+    if (currentIdx === -1) {
+      nextIdx = delta === 1 ? 0 : items.length - 1;
+    } else {
+      nextIdx = (currentIdx + delta + items.length) % items.length;
+    }
+
+    e.preventDefault();
+    items[nextIdx].focus();
+  }
 </script>
 
-<section class="settings">
+<section class="settings" bind:this={sectionEl}>
   <div class="settings-header">
-    <button class="back" onclick={onBack}>← Back</button>
+    <button class="back" bind:this={backEl} onclick={onBack}>← Back</button>
   </div>
   <div class="settings-body">
     <label class="setting-row">
@@ -354,6 +399,10 @@
           <dd>
             <kbd>PageUp</kbd> <kbd>PageDown</kbd> <kbd>Home</kbd> <kbd>End</kbd>
           </dd>
+        </div>
+        <div class="shortcut-item">
+          <dt>Navigate settings</dt>
+          <dd><kbd>↑</kbd> <kbd>↓</kbd></dd>
         </div>
       </dl>
       <p class="setting-hint">

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { dispatchShortcut, matchShortcut, type Shortcut } from "./shortcuts";
+
+function event(
+  key: string,
+  opts: Partial<Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "shiftKey" | "altKey">> & {
+    target?: EventTarget | null;
+  } = {},
+): KeyboardEvent {
+  return {
+    key,
+    metaKey: opts.metaKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    altKey: opts.altKey ?? false,
+    target: opts.target ?? null,
+    preventDefault: vi.fn(),
+  } as unknown as KeyboardEvent;
+}
+
+describe("matchShortcut", () => {
+  it("matches a plain letter key case-insensitively", () => {
+    const def: Shortcut = { key: "u", run: () => {} };
+    expect(matchShortcut(event("u"), def)).toBe(true);
+    expect(matchShortcut(event("U", { shiftKey: true }), def)).toBe(true);
+  });
+
+  it("rejects a plain symbol when shift is held (different character)", () => {
+    const def: Shortcut = { key: "/", run: () => {} };
+    expect(matchShortcut(event("/"), def)).toBe(true);
+    expect(matchShortcut(event("?", { shiftKey: true }), def)).toBe(false);
+  });
+
+  it("requires explicit shift when mods include it", () => {
+    const def: Shortcut = { key: "a", mods: ["cmdOrCtrl", "shift"], run: () => {} };
+    expect(matchShortcut(event("A", { metaKey: true, shiftKey: true }), def)).toBe(true);
+    expect(matchShortcut(event("a", { metaKey: true }), def)).toBe(false);
+  });
+
+  it("cmdOrCtrl matches either modifier", () => {
+    const def: Shortcut = { key: "r", mods: ["cmdOrCtrl"], run: () => {} };
+    expect(matchShortcut(event("r", { metaKey: true }), def)).toBe(true);
+    expect(matchShortcut(event("r", { ctrlKey: true }), def)).toBe(true);
+    expect(matchShortcut(event("r"), def)).toBe(false);
+  });
+
+  it("cmd-only rejects ctrl-only presses", () => {
+    const def: Shortcut = { key: ",", mods: ["cmd"], run: () => {} };
+    expect(matchShortcut(event(",", { metaKey: true }), def)).toBe(true);
+    expect(matchShortcut(event(",", { ctrlKey: true }), def)).toBe(false);
+  });
+
+  it("rejects unwanted modifiers when mods are empty", () => {
+    const def: Shortcut = { key: "u", run: () => {} };
+    expect(matchShortcut(event("u", { metaKey: true }), def)).toBe(false);
+    expect(matchShortcut(event("u", { altKey: true }), def)).toBe(false);
+  });
+
+  it("matches named keys like Enter or Backspace", () => {
+    const def: Shortcut = { key: "Backspace", run: () => {} };
+    expect(matchShortcut(event("Backspace"), def)).toBe(true);
+    expect(matchShortcut(event("Enter"), def)).toBe(false);
+  });
+});
+
+describe("dispatchShortcut", () => {
+  function input(): HTMLElement {
+    return { tagName: "INPUT" } as HTMLElement;
+  }
+
+  it("runs the matching shortcut and preventDefaults", () => {
+    const run = vi.fn();
+    const e = event("u");
+    const handled = dispatchShortcut(e, [{ key: "u", run }]);
+    expect(handled).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+    expect(e.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("skips shortcuts when focus is in a text field", () => {
+    const run = vi.fn();
+    const e = event("u", { target: input() });
+    const handled = dispatchShortcut(e, [{ key: "u", run }]);
+    expect(handled).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("runs allowInInput shortcuts even from a text field", () => {
+    const run = vi.fn();
+    const e = event(",", { metaKey: true, target: input() });
+    const handled = dispatchShortcut(e, [
+      { key: ",", mods: ["cmd"], allowInInput: true, run },
+    ]);
+    expect(handled).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("when guard returning falsy lets the key fall through", () => {
+    const run = vi.fn();
+    const e = event("u");
+    const handled = dispatchShortcut(e, [{ key: "u", when: () => false, run }]);
+    expect(handled).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("stops at the first matching shortcut", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    dispatchShortcut(event("u"), [
+      { key: "u", run: first },
+      { key: "u", run: second },
+    ]);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,5 +1,11 @@
+// @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
-import { dispatchShortcut, matchShortcut, type Shortcut } from "./shortcuts";
+import {
+  dispatchShortcut,
+  isTextCaretTarget,
+  matchShortcut,
+  type Shortcut,
+} from "./shortcuts";
 
 function event(
   key: string,
@@ -60,6 +66,33 @@ describe("matchShortcut", () => {
     const def: Shortcut = { key: "Backspace", run: () => {} };
     expect(matchShortcut(event("Backspace"), def)).toBe(true);
     expect(matchShortcut(event("Enter"), def)).toBe(false);
+  });
+});
+
+describe("isTextCaretTarget", () => {
+  it("returns true for textareas and text-type inputs", () => {
+    const textarea = document.createElement("textarea");
+    const text = document.createElement("input");
+    text.type = "text";
+    const search = document.createElement("input");
+    search.type = "search";
+    expect(isTextCaretTarget(textarea)).toBe(true);
+    expect(isTextCaretTarget(text)).toBe(true);
+    expect(isTextCaretTarget(search)).toBe(true);
+  });
+
+  it("returns false for checkboxes, radios, buttons, selects", () => {
+    const check = document.createElement("input");
+    check.type = "checkbox";
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    const btn = document.createElement("button");
+    const select = document.createElement("select");
+    expect(isTextCaretTarget(check)).toBe(false);
+    expect(isTextCaretTarget(radio)).toBe(false);
+    expect(isTextCaretTarget(btn)).toBe(false);
+    expect(isTextCaretTarget(select)).toBe(false);
+    expect(isTextCaretTarget(null)).toBe(false);
   });
 });
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -53,6 +53,18 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 }
 
+// Text-caret targets — places where arrow keys move the caret natively and
+// must not be hijacked. Narrower than `isEditableTarget`: SELECT and checkbox
+// INPUTs are fine to intercept for focus navigation.
+export function isTextCaretTarget(target: EventTarget | null): boolean {
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (target instanceof HTMLInputElement) {
+    const type = target.type;
+    return type !== "checkbox" && type !== "radio";
+  }
+  return false;
+}
+
 export function dispatchShortcut(e: KeyboardEvent, defs: Shortcut[]): boolean {
   const inField = isEditableTarget(e.target);
   for (const def of defs) {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,67 @@
+export type Mod = "cmd" | "ctrl" | "cmdOrCtrl" | "shift" | "alt";
+
+export type Shortcut = {
+  key: string;
+  mods?: Mod[];
+  when?: () => boolean;
+  allowInInput?: boolean;
+  run: () => void | Promise<void>;
+};
+
+function normalizeKey(key: string): string {
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+function isLetter(key: string): boolean {
+  return key.length === 1 && key >= "a" && key <= "z";
+}
+
+export function matchShortcut(e: KeyboardEvent, def: Shortcut): boolean {
+  const key = normalizeKey(e.key);
+  if (key !== def.key) return false;
+
+  const mods = new Set(def.mods ?? []);
+  const wantCmdOrCtrl = mods.has("cmdOrCtrl");
+  const wantCmd = mods.has("cmd");
+  const wantCtrl = mods.has("ctrl");
+  const wantShift = mods.has("shift");
+  const wantAlt = mods.has("alt");
+
+  if (wantCmdOrCtrl) {
+    if (!(e.metaKey || e.ctrlKey)) return false;
+  } else {
+    if (e.metaKey !== wantCmd) return false;
+    if (e.ctrlKey !== wantCtrl) return false;
+  }
+
+  // Shift controls letter case; when not explicitly required, ignore it for
+  // letter keys so "u" and "U" both match. For symbols like "/", enforce
+  // strictly — Shift+/ produces "?", a different binding.
+  if (wantShift) {
+    if (!e.shiftKey) return false;
+  } else if (!isLetter(key) && e.shiftKey) {
+    return false;
+  }
+
+  if (e.altKey !== wantAlt) return false;
+  return true;
+}
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  const tag = el?.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+}
+
+export function dispatchShortcut(e: KeyboardEvent, defs: Shortcut[]): boolean {
+  const inField = isEditableTarget(e.target);
+  for (const def of defs) {
+    if (!matchShortcut(e, def)) continue;
+    if (inField && !def.allowInInput) continue;
+    if (def.when && !def.when()) continue;
+    e.preventDefault();
+    void def.run();
+    return true;
+  }
+  return false;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,6 +46,7 @@
     type Theme,
   } from "$lib/storage";
   import type { NotificationItem, Tab, WatchedItem } from "$lib/types";
+  import { dispatchShortcut, isEditableTarget, type Shortcut } from "$lib/shortcuts";
   import Auth from "$lib/components/Auth.svelte";
   import ItemList from "$lib/components/ItemList.svelte";
   import Settings from "$lib/components/Settings.svelte";
@@ -452,6 +453,59 @@
     return parts.join("+");
   }
 
+  const inLoadedPage = () => phase === "loaded" && !showingSettings;
+
+  const shortcuts: Shortcut[] = [
+    {
+      key: "Backspace",
+      when: () => showingSettings,
+      run: () => {
+        showingSettings = false;
+      },
+    },
+    {
+      key: ",",
+      mods: ["cmd"],
+      allowInInput: true,
+      when: inLoadedPage,
+      run: () => {
+        showingSettings = true;
+      },
+    },
+    {
+      key: "/",
+      when: inLoadedPage,
+      run: openSearch,
+    },
+    {
+      key: "f",
+      mods: ["cmdOrCtrl"],
+      when: inLoadedPage,
+      run: openSearch,
+    },
+    {
+      key: "r",
+      mods: ["cmdOrCtrl"],
+      when: inLoadedPage,
+      run: () => {
+        if (!loading) triggerRefresh();
+      },
+    },
+    {
+      key: "a",
+      mods: ["cmdOrCtrl", "shift"],
+      when: inLoadedPage,
+      run: () => {
+        if (visibleUnreadCount > 0) void markAllVisibleAsRead();
+      },
+    },
+    {
+      key: "u",
+      when: inLoadedPage,
+      run: toggleUnreadOnly,
+    },
+  ];
+
   async function handleGlobalKey(e: KeyboardEvent) {
     if (capturingShortcut) {
       e.preventDefault();
@@ -474,66 +528,10 @@
       return;
     }
 
-    if (e.key === "Backspace" && showingSettings) {
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
-      e.preventDefault();
-      showingSettings = false;
-      return;
-    }
+    if (dispatchShortcut(e, shortcuts)) return;
 
-    // macOS convention: Cmd+, opens the Preferences / Settings pane.
-    if (e.metaKey && e.key === "," && !showingSettings && phase === "loaded") {
-      e.preventDefault();
-      showingSettings = true;
-      return;
-    }
-
-    // Arrow keys walk the selection, Enter opens, Page/Home/End still scroll.
     if (phase === "loaded" && !showingSettings) {
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-
-      // "/" or Cmd/Ctrl+F reveals the search input and moves focus to it.
-      // `/` alone is only grabbed when no modifier is held — otherwise
-      // Shift+/ (which also produces "?") could hijack other shortcuts.
-      if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        e.preventDefault();
-        openSearch();
-        return;
-      }
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
-        e.preventDefault();
-        openSearch();
-        return;
-      }
-
-      // Cmd/Ctrl+R — reload. preventDefault is important: the webview's
-      // default binding would otherwise reload the SPA and drop all state.
-      if (
-        (e.metaKey || e.ctrlKey) &&
-        !e.shiftKey &&
-        !e.altKey &&
-        e.key.toLowerCase() === "r"
-      ) {
-        e.preventDefault();
-        if (!loading) triggerRefresh();
-        return;
-      }
-
-      // Cmd/Ctrl+Shift+A — mark all visible as read.
-      if (
-        (e.metaKey || e.ctrlKey) &&
-        e.shiftKey &&
-        !e.altKey &&
-        e.key.toLowerCase() === "a"
-      ) {
-        e.preventDefault();
-        if (visibleUnreadCount > 0) void markAllVisibleAsRead();
-        return;
-      }
+      if (isEditableTarget(e.target)) return;
 
       switch (e.key) {
         case "ArrowDown":


### PR DESCRIPTION
## Summary

- Add `U` keyboard shortcut to toggle the unread-only filter (case-insensitive, not hijacked inside text fields).
- Extract keyboard-shortcut handling out of `+page.svelte` into a new declarative `src/lib/shortcuts.ts` module with `Shortcut[]` + `matchShortcut` / `dispatchShortcut` / `isEditableTarget` / `isTextCaretTarget`. New unit tests in `src/lib/shortcuts.test.ts`. `handleGlobalKey` now lists shortcuts as data and delegates to `dispatchShortcut`.
- Settings pane is now keyboard-navigable with ↑/↓ — focus moves between every enabled button / select / checkbox in the pane. Text inputs keep native caret behavior; the existing shortcut-capture flow is left alone. Back button auto-focuses on open. The in-app shortcut cheat-sheet lists the new bindings.

## Why

- Asked for a shortcut on the unread-only chip.
- `handleGlobalKey` was growing an imperative if-ladder per shortcut — moving to a declarative list keeps future additions to one entry and centralizes modifier / input-focus rules.
- Settings required mouse interaction to flip between rows; this closes the last keyboard-only gap.

## Notes for reviewers

- `matchShortcut` treats Shift as case-insensitive for letter keys only — `u`/`U` both match, but `Shift+/` (which is `?`) does not match a `/` binding. Covered by tests.
- `isTextCaretTarget` is narrower than `isEditableTarget` on purpose: `SELECT` and `checkbox`/`radio` inputs are fine for ↑/↓ focus nav, while text inputs/textareas are not.
- While Settings is open, the main view's ↑/↓ list nav is a no-op (guarded by `phase === "loaded" && !showingSettings`), so there is no double-handling between the two window listeners.

## Test plan

- [ ] `pnpm check` passes
- [ ] `pnpm test` passes (36 tests)
- [ ] In the popup: press `U` to toggle the unread-only chip; confirm it does NOT fire while typing in a text field
- [ ] In the popup: confirm `/`, `Cmd+F`, `Cmd+R`, `Cmd+Shift+A`, `Cmd+,` still behave as before
- [ ] Open Settings with `Cmd+,`; press ↑/↓ to cycle focus through Back → Refresh → Notifications → ... → Import; wrap at ends
- [ ] In Settings, focus a select → press Space/Enter to open dropdown → arrow through options → Enter to confirm (native)
- [ ] In Settings, focus the org/repo text input → typing works; ↑/↓ do not steal focus; Tab moves on
- [ ] In Settings, click the shortcut-capture button → press a combo → confirm ↑/↓ are not hijacked during capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)