### PR TITLE
fix: stop notification flood on restart by parking worker until config is applied

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -53,6 +53,14 @@ pub struct BackgroundState {
     pub last_error: Option<String>,
     pub authenticated: bool,
 
+    /// Flipped to true the first time the frontend pushes its persisted
+    /// config. Until then the worker stays parked — kicking off a cycle
+    /// with the default tab/orgs would fetch one set of items, then the
+    /// real config arrives and overwrites tab/orgs; the next cycle would
+    /// diff against the old snapshot and fire "Closed" notifications for
+    /// every item the new filters dropped.
+    pub config_applied: bool,
+
     pub has_loaded_once: bool,
     pub prev_items: HashMap<u64, WatchedItem>,
     pub prev_thread_updated_at: HashMap<u64, String>,
@@ -433,6 +441,11 @@ pub fn spawn_worker(app: AppHandle, handle: BackgroundHandle) {
     handle.with_state(|s| s.authenticated = has_token);
 
     tauri::async_runtime::spawn(async move {
+        // Park until the frontend has pushed its persisted config at
+        // least once. See BackgroundState::config_applied for why.
+        while !handle.with_state(|s| s.config_applied) {
+            handle.wake.notified().await;
+        }
         loop {
             run_cycle(&app, &handle).await;
             let interval_ms = handle.with_state(|s| s.interval_ms.max(MIN_INTERVAL_MS));
@@ -475,7 +488,13 @@ pub fn set_background_config(
     // so we reset the diff anchors and wake the worker. `badge_dirty` is
     // the filter-only path that doesn't need a refetch.
     let (trigger, badge_dirty) = handle.with_state(|s| {
-        let mut trigger = false;
+        // First push from the frontend always wakes the worker — the
+        // main loop is parked on `config_applied` and the tab/orgs may
+        // happen to equal the defaults, which would leave `trigger`
+        // false and strand the worker forever.
+        let first_apply = !s.config_applied;
+        s.config_applied = true;
+        let mut trigger = first_apply;
         let mut badge_dirty = false;
         if let Some(tab) = config.tab {
             if tab != s.tab {


### PR DESCRIPTION
## Summary

On every restart, eir would fire a flood of \"Closed\" notifications for items the user's filters drop. Root cause was a race between `spawn_worker` (which started fetching immediately with default state — `tab=All`, no watched orgs) and the frontend's `onMount`-time `pushFullConfig()` which overwrote `tab`/`watched_orgs` after the first cycle's results landed. The next cycle then diffed the new tab's items against the old tab's `prev_items` snapshot, and `removed_items` returned everything that fell out — surfaced as one OS notification per item.

Fix is structural rather than patching the diff path: add `BackgroundState.config_applied` and park `spawn_worker`'s main loop on `wake.notified().await` until the frontend's first `set_background_config` flips it. The first push always wakes the worker (even if `tab`/`orgs` happen to equal the defaults) so the worker can't be stranded.

## Changed

- `BackgroundState`: new `config_applied: bool` field with doc comment explaining the flood scenario
- `spawn_worker`: park on `config_applied` before entering the cycle loop
- `set_background_config`: snapshot `!config_applied` as `first_apply`, set the flag, and seed `trigger = first_apply` so the parked worker always wakes on the first push

No frontend changes — `+page.svelte`'s `onMount` already awaits `pushFullConfig()` before anything else, which is exactly the order this fix needs.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (63 pass)
- [ ] `pnpm tauri dev`: cold start with persisted token + non-default tab/orgs → no notification flood
- [ ] sign-out / sign-in cycle → no flood
- [ ] tab switch after warm-up → only the actually-changed items notify

🤖 Generated with [Claude Code](https://claude.com/claude-code)