### PR TITLE
feat: surface latest comment body in notifications and list

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -12,7 +12,7 @@ use crate::auth::{clear_stored_token, AppState};
 use crate::diff::{compute_item_changes, fresh_notifications, item_key, removed_items};
 use crate::github::{
     build_octocrab, fetch_item_states_with, fetch_notifications_with, fetch_watched_with, ItemRef,
-    NotificationItem, WatchedItem,
+    LatestComment, NotificationItem, WatchedItem,
 };
 
 pub const STATE_UPDATED_EVENT: &str = "state-updated";
@@ -203,6 +203,105 @@ fn send_os_notification(app: &AppHandle, title: &str, body: &str) {
     }
 }
 
+/// Truncate a string to at most `max` Unicode scalars, appending an ellipsis
+/// when shortened. The ellipsis counts toward the budget so callers can sum
+/// pieces (`prefix` + truncated body + `suffix`) and stay inside a known cap.
+fn truncate_chars(s: &str, max: usize) -> String {
+    let len = s.chars().count();
+    if len <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    // Reserve one slot for the ellipsis so the returned string fits in `max`.
+    let take = max - 1;
+    let truncated: String = s.chars().take(take).collect();
+    format!("{truncated}…")
+}
+
+/// Flatten a comment body for one-line display: drop fenced-code lines, then
+/// collapse all whitespace runs (including embedded newlines) into single
+/// spaces. Without this, multi-paragraph comments would push the notification
+/// well past its visible budget.
+pub(crate) fn flatten_comment_body(body: &str) -> String {
+    let mut in_fence = false;
+    let mut kept: Vec<&str> = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        kept.push(line);
+    }
+    kept.join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+const NOTIF_TITLE_BUDGET: usize = 60;
+const NOTIF_BODY_BUDGET: usize = 140;
+
+fn build_title(repo: &str, kind: &str, number: u64, item_title: &str) -> String {
+    let prefix = match kind {
+        "pr" => format!("{repo}#{number}"),
+        "issue" => format!("{repo}#{number}"),
+        _ => format!("{repo}#{number}"),
+    };
+    if item_title.is_empty() {
+        return prefix;
+    }
+    let head = format!("{prefix}: ");
+    let remaining = NOTIF_TITLE_BUDGET.saturating_sub(head.chars().count());
+    if remaining == 0 {
+        return prefix;
+    }
+    format!("{head}{}", truncate_chars(item_title, remaining))
+}
+
+/// Build the body line. When a `LatestComment` is supplied the body is
+/// `@author: <flattened excerpt>`, optionally annotated with `(+N件)` for
+/// burst comment additions. Otherwise we fall back to the short reason.
+fn build_comment_body(latest: &LatestComment, extra_count: u32) -> String {
+    let flat = flatten_comment_body(&latest.body_text);
+    let suffix = if extra_count > 0 {
+        format!(" (+{extra_count}件)")
+    } else {
+        String::new()
+    };
+    let head = format!("@{}: ", latest.author);
+    let body_budget = NOTIF_BODY_BUDGET
+        .saturating_sub(head.chars().count())
+        .saturating_sub(suffix.chars().count());
+    let excerpt = if body_budget == 0 {
+        String::new()
+    } else {
+        truncate_chars(&flat, body_budget)
+    };
+    format!("{head}{excerpt}{suffix}")
+}
+
+/// How many "extra" comments rolled into a single item-change update. We
+/// surface only the most recent one in the body and tag the rest as `(+N件)`
+/// so a burst doesn't spam multiple banners.
+fn extra_comment_count(reason: &str) -> u32 {
+    // `describe_item_change` emits "+N comment" / "+N comments". Anything else
+    // we treat as zero extras.
+    let Some(rest) = reason.strip_prefix('+') else {
+        return 0;
+    };
+    let head = rest.split_whitespace().next();
+    match head.and_then(|n| n.parse::<u32>().ok()) {
+        Some(n) if n >= 1 => n - 1,
+        _ => 0,
+    }
+}
+
 async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     // Pull the current token off AppState. No token = sign-in required, and
     // we clear cached state without emitting the "loading" prelude because
@@ -295,24 +394,41 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     let item_changes = compute_item_changes(&prev_items, &items, &notified_keys);
     let removed = removed_items(&prev_items, &items, &notified_keys);
 
+    // Index the freshly-fetched watched items by item_key so the fresh-thread
+    // path (which only carries subject metadata) can pick up the matching
+    // `latest_comment`. Items present in the search result but absent from the
+    // notifications inbox are still useful here for the item-change path.
+    let items_by_key: HashMap<String, &WatchedItem> = items
+        .iter()
+        .map(|i| (item_key(&i.repo, i.kind, i.number), i))
+        .collect();
+
     if has_loaded_once && notify_enabled {
         for n in &fresh {
-            let suffix = match n.number {
-                Some(num) => format!("{}#{}", n.repo, num),
-                None => n.repo.clone(),
+            let Some(num) = n.number else { continue };
+            let key = item_key(&n.repo, n.kind, num);
+            let title = build_title(&n.repo, n.kind, num, &n.title);
+            let body = match items_by_key
+                .get(&key)
+                .and_then(|i| i.latest_comment.as_ref())
+            {
+                Some(c) => build_comment_body(c, 0),
+                None => reason_label(&n.reason).to_string(),
             };
-            let title = reason_label(&n.reason);
-            let body = format!("{suffix} — {}", n.title);
-            eprintln!("[eir] notify fresh: {title} — {suffix}");
-            send_os_notification(app, title, &body);
+            eprintln!("[eir] notify fresh: {} — {key}", n.reason);
+            send_os_notification(app, &title, &body);
         }
         for ic in &item_changes {
-            let body = format!("{}#{} — {}", ic.item.repo, ic.item.number, ic.item.title);
+            let title = build_title(&ic.item.repo, ic.item.kind, ic.item.number, &ic.item.title);
+            let body = match ic.item.latest_comment.as_ref() {
+                Some(c) => build_comment_body(c, extra_comment_count(&ic.reason)),
+                None => ic.reason.clone(),
+            };
             eprintln!(
                 "[eir] notify item-change: {} — {}#{}",
                 ic.reason, ic.item.repo, ic.item.number
             );
-            send_os_notification(app, &ic.reason, &body);
+            send_os_notification(app, &title, &body);
         }
         if !removed.is_empty() {
             let refs: Vec<ItemRef> = removed
@@ -694,5 +810,151 @@ mod drive_progressive_fetches_tests {
         let ((items_res, notifs_res), _) = joined;
         assert_eq!(items_res.unwrap(), vec![9]);
         assert_eq!(notifs_res.unwrap(), vec!["hi"]);
+    }
+}
+
+#[cfg(test)]
+mod notification_body_tests {
+    use super::*;
+
+    fn make_comment(author: &str, body: &str) -> LatestComment {
+        LatestComment {
+            author: author.into(),
+            author_avatar: "".into(),
+            body_text: body.into(),
+            created_at: "2026-04-27T00:00:00Z".into(),
+            url: "https://example.com/c/1".into(),
+        }
+    }
+
+    #[test]
+    fn truncate_chars_passes_through_short_strings() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_chars_appends_ellipsis_on_overflow() {
+        // The ellipsis counts toward the max so the result fits in 5 chars.
+        assert_eq!(truncate_chars("abcdefgh", 5), "abcd…");
+    }
+
+    #[test]
+    fn truncate_chars_counts_unicode_scalars_not_bytes() {
+        // Each kana is 3 bytes in UTF-8; truncating by chars must not split a
+        // codepoint mid-byte and corrupt the output.
+        let s = "あいうえおかきく";
+        assert_eq!(truncate_chars(s, 4), "あいう…");
+        assert_eq!(truncate_chars(s, 8), "あいうえおかきく");
+    }
+
+    #[test]
+    fn truncate_chars_zero_max_returns_empty() {
+        assert_eq!(truncate_chars("hello", 0), "");
+    }
+
+    #[test]
+    fn flatten_comment_body_collapses_whitespace_and_newlines() {
+        let raw = "first line\n\nsecond   line\n\tthird";
+        assert_eq!(flatten_comment_body(raw), "first line second line third");
+    }
+
+    #[test]
+    fn flatten_comment_body_strips_fenced_code_blocks() {
+        let raw = "before\n```rust\nfn main() {}\n```\nafter";
+        assert_eq!(flatten_comment_body(raw), "before after");
+    }
+
+    #[test]
+    fn flatten_comment_body_handles_unclosed_fence() {
+        // An unclosed fence still suppresses lines after the opener so the
+        // banner doesn't dump a half-rendered code block on the user.
+        let raw = "before\n```\nfn main() {}";
+        assert_eq!(flatten_comment_body(raw), "before");
+    }
+
+    #[test]
+    fn build_title_combines_repo_number_and_truncated_title() {
+        let title = build_title("owner/repo", "pr", 123, "PR title goes here");
+        assert_eq!(title, "owner/repo#123: PR title goes here");
+    }
+
+    #[test]
+    fn build_title_truncates_long_titles_to_fit_budget() {
+        let long = "a".repeat(200);
+        let title = build_title("o/r", "pr", 1, &long);
+        // Total length stays inside NOTIF_TITLE_BUDGET (60 chars). The
+        // "o/r#1: " prefix consumes 7 chars, leaving 53 for the truncated
+        // title (including its ellipsis).
+        assert!(title.starts_with("o/r#1: "));
+        let after_prefix = title.trim_start_matches("o/r#1: ");
+        assert!(
+            after_prefix.ends_with('…'),
+            "expected ellipsis suffix in {title}"
+        );
+        assert!(title.chars().count() <= NOTIF_TITLE_BUDGET);
+        assert_eq!(after_prefix.chars().count(), 53);
+    }
+
+    #[test]
+    fn build_title_falls_back_when_title_is_empty() {
+        assert_eq!(build_title("o/r", "pr", 5, ""), "o/r#5");
+    }
+
+    #[test]
+    fn build_comment_body_renders_author_and_excerpt() {
+        let c = make_comment("alice", "looks good to me");
+        assert_eq!(build_comment_body(&c, 0), "@alice: looks good to me");
+    }
+
+    #[test]
+    fn build_comment_body_appends_extra_count_suffix() {
+        let c = make_comment("alice", "first comment");
+        assert_eq!(build_comment_body(&c, 2), "@alice: first comment (+2件)");
+    }
+
+    #[test]
+    fn build_comment_body_truncates_long_excerpts_within_budget() {
+        let long = "x".repeat(500);
+        let c = make_comment("alice", &long);
+        let body = build_comment_body(&c, 0);
+        // "@alice: " is 8 chars; the excerpt fills the remaining 132 chars
+        // including its ellipsis, keeping the whole body inside the budget.
+        assert!(body.starts_with("@alice: "));
+        assert!(body.ends_with('…'));
+        assert!(body.chars().count() <= NOTIF_BODY_BUDGET);
+        assert_eq!(body.chars().count(), 8 + 132);
+    }
+
+    #[test]
+    fn build_comment_body_keeps_excerpt_when_suffix_is_present() {
+        // The trailing `(+N件)` must not push the excerpt past the budget.
+        let long = "x".repeat(500);
+        let c = make_comment("a", &long);
+        let body = build_comment_body(&c, 9);
+        assert!(body.ends_with(" (+9件)"));
+        assert!(body.chars().count() <= NOTIF_BODY_BUDGET);
+    }
+
+    #[test]
+    fn build_comment_body_normalizes_multiline_input() {
+        let c = make_comment("bob", "line1\n\nline2\n```\ncode\n```\nline3");
+        assert_eq!(build_comment_body(&c, 0), "@bob: line1 line2 line3");
+    }
+
+    #[test]
+    fn extra_comment_count_pulls_n_minus_one_from_plus_n_reasons() {
+        assert_eq!(extra_comment_count("+1 comment"), 0);
+        assert_eq!(extra_comment_count("+3 comments"), 2);
+        assert_eq!(extra_comment_count("+10 comments"), 9);
+    }
+
+    #[test]
+    fn extra_comment_count_returns_zero_for_unrelated_reasons() {
+        assert_eq!(extra_comment_count("Now merged"), 0);
+        assert_eq!(extra_comment_count("Updated"), 0);
+        assert_eq!(extra_comment_count("alice approved"), 0);
+        assert_eq!(extra_comment_count("+abc nonsense"), 0);
+        assert_eq!(extra_comment_count(""), 0);
     }
 }

--- a/src-tauri/src/diff.rs
+++ b/src-tauri/src/diff.rs
@@ -171,6 +171,7 @@ mod tests {
             reviewers: Vec::new(),
             commenters: Vec::new(),
             ci_status: None,
+            latest_comment: None,
         }
     }
 

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -72,6 +72,16 @@ pub struct Commenter {
 }
 
 #[derive(Serialize, Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct LatestComment {
+    pub author: String,
+    pub author_avatar: String,
+    pub body_text: String,
+    pub created_at: String,
+    pub url: String,
+}
+
+#[derive(Serialize, Clone)]
 pub struct WatchedItem {
     pub id: u64,
     pub kind: &'static str,
@@ -88,6 +98,7 @@ pub struct WatchedItem {
     pub reviewers: Vec<Reviewer>,
     pub commenters: Vec<Commenter>,
     pub ci_status: Option<&'static str>, // "success" | "pending" | "failure" | "error"
+    pub latest_comment: Option<LatestComment>,
 }
 
 fn queries_for_tab(tab: &str, watched_orgs: &[String]) -> Vec<String> {
@@ -134,7 +145,19 @@ fragment PrFields on PullRequest {
   updatedAt
   state
   isDraft
-  comments { totalCount }
+  comments(last: 1) {
+    totalCount
+    nodes {
+      author {
+        login
+        ... on User { avatarUrl }
+        ... on Bot { avatarUrl }
+      }
+      bodyText
+      createdAt
+      url
+    }
+  }
   repository { nameWithOwner }
   author {
     login
@@ -183,6 +206,9 @@ fragment IssueFields on Issue {
         ... on User { avatarUrl }
         ... on Bot { avatarUrl }
       }
+      bodyText
+      createdAt
+      url
     }
   }
   repository { nameWithOwner }
@@ -247,7 +273,7 @@ struct PrNode {
     state: String,
     #[serde(default)]
     is_draft: bool,
-    comments: CountNode,
+    comments: IssueCommentsNode,
     repository: RepoNode,
     author: Option<AuthorNode>,
     reviews: NodeList<ReviewNode>,
@@ -271,12 +297,6 @@ struct IssueNode {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct CountNode {
-    total_count: u32,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct IssueCommentsNode {
     total_count: u32,
     #[serde(default)]
@@ -284,8 +304,15 @@ struct IssueCommentsNode {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct IssueCommentNode {
     author: Option<AuthorNode>,
+    #[serde(default)]
+    body_text: String,
+    #[serde(default)]
+    created_at: String,
+    #[serde(default)]
+    url: String,
 }
 
 #[derive(Deserialize)]
@@ -340,6 +367,27 @@ struct CommitNode {
 #[derive(Deserialize)]
 struct StatusCheckRollup {
     state: String,
+}
+
+/// Pick the most recent comment with a real author from a `comments(last: N)`
+/// slice. GraphQL returns the slice oldest→newest, so the back of the vec is
+/// the newest. Anonymous (deleted-user) comments are skipped — there's no
+/// useful "@author" to display.
+fn latest_comment_from(nodes: &[Option<IssueCommentNode>]) -> Option<LatestComment> {
+    for slot in nodes.iter().rev() {
+        let Some(node) = slot else { continue };
+        let Some(author) = node.author.as_ref() else {
+            continue;
+        };
+        return Some(LatestComment {
+            author: author.login.clone(),
+            author_avatar: author.avatar_url.clone().unwrap_or_default(),
+            body_text: node.body_text.clone(),
+            created_at: node.created_at.clone(),
+            url: node.url.clone(),
+        });
+    }
+    None
 }
 
 fn map_item_state(raw: &str) -> &'static str {
@@ -434,6 +482,8 @@ fn pr_to_item(pr: PrNode) -> WatchedItem {
         .and_then(|c| c.commit.status_check_rollup)
         .map(|r| map_ci_state(&r.state));
 
+    let latest_comment = latest_comment_from(&pr.comments.nodes);
+
     WatchedItem {
         id: pr.database_id,
         kind: "pr",
@@ -450,6 +500,7 @@ fn pr_to_item(pr: PrNode) -> WatchedItem {
         reviewers,
         commenters: Vec::new(),
         ci_status,
+        latest_comment,
     }
 }
 
@@ -470,6 +521,8 @@ fn issue_to_item(issue: IssueNode) -> WatchedItem {
     // in the list too — they often drive the discussion and showing only
     // "others" would hide that. The frontend can decide whether to draw
     // the author chip differently.
+    let latest_comment = latest_comment_from(&issue.comments.nodes);
+
     let mut seen_logins: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut commenters: Vec<Commenter> = Vec::new();
     for c in issue.comments.nodes.into_iter().flatten() {
@@ -499,6 +552,7 @@ fn issue_to_item(issue: IssueNode) -> WatchedItem {
         reviewers: Vec::new(),
         commenters,
         ci_status: None,
+        latest_comment,
     }
 }
 
@@ -1278,6 +1332,97 @@ mod tests {
         // Legacy/older backend shape without `nodes` must still deserialize.
         let item = issue_to_item(make_issue_node(10, "o/r", 7));
         assert!(item.commenters.is_empty());
+    }
+
+    #[test]
+    fn issue_latest_comment_picks_most_recent_node() {
+        // GraphQL returns the slice oldest→newest, so the LAST element is the
+        // newest. issue_to_item must surface that one as `latest_comment`.
+        let item = issue_to_item(make_issue_node_with_comments(json!([
+            {
+                "author": { "login": "alice", "avatarUrl": "a-url" },
+                "bodyText": "first",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "url": "https://github.com/o/r/issues/1#c1"
+            },
+            {
+                "author": { "login": "bob", "avatarUrl": "b-url" },
+                "bodyText": "second is newest",
+                "createdAt": "2026-02-01T00:00:00Z",
+                "url": "https://github.com/o/r/issues/1#c2"
+            }
+        ])));
+        let lc = item.latest_comment.expect("latest_comment present");
+        assert_eq!(lc.author, "bob");
+        assert_eq!(lc.author_avatar, "b-url");
+        assert_eq!(lc.body_text, "second is newest");
+        assert_eq!(lc.created_at, "2026-02-01T00:00:00Z");
+        assert_eq!(lc.url, "https://github.com/o/r/issues/1#c2");
+    }
+
+    #[test]
+    fn issue_latest_comment_skips_anonymous_authors_walking_backwards() {
+        // The newest comment was made by a deleted user; we still want a
+        // useful "@author:" line, so fall back to the second-newest.
+        let item = issue_to_item(make_issue_node_with_comments(json!([
+            {
+                "author": { "login": "alice", "avatarUrl": "a" },
+                "bodyText": "kept",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "url": "u1"
+            },
+            { "author": null, "bodyText": "ghost", "createdAt": "2026-02-01T00:00:00Z", "url": "u2" }
+        ])));
+        let lc = item.latest_comment.expect("falls back to second-newest");
+        assert_eq!(lc.author, "alice");
+        assert_eq!(lc.body_text, "kept");
+    }
+
+    #[test]
+    fn issue_latest_comment_is_none_when_no_comments() {
+        let item = issue_to_item(make_issue_node(10, "o/r", 7));
+        assert!(item.latest_comment.is_none());
+    }
+
+    #[test]
+    fn pr_latest_comment_uses_last_node() {
+        let pr: PrNode = serde_json::from_value(json!({
+            "databaseId": 1,
+            "title": "t",
+            "number": 1,
+            "url": "https://github.com/o/r/pull/1",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "state": "OPEN",
+            "comments": {
+                "totalCount": 1,
+                "nodes": [
+                    {
+                        "author": { "login": "carol", "avatarUrl": "c" },
+                        "bodyText": "looks good",
+                        "createdAt": "2026-04-01T00:00:00Z",
+                        "url": "https://github.com/o/r/pull/1#c1"
+                    }
+                ]
+            },
+            "repository": { "nameWithOwner": "o/r" },
+            "author": { "login": "author", "avatarUrl": "a" },
+            "reviews": { "nodes": [] },
+            "reviewRequests": { "nodes": [] },
+            "commits": { "nodes": [] }
+        }))
+        .unwrap();
+        let item = pr_to_item(pr);
+        let lc = item.latest_comment.expect("latest_comment present");
+        assert_eq!(lc.author, "carol");
+        assert_eq!(lc.body_text, "looks good");
+        assert_eq!(lc.url, "https://github.com/o/r/pull/1#c1");
+    }
+
+    #[test]
+    fn pr_latest_comment_is_none_when_no_nodes() {
+        let pr = make_pr(json!([]), json!([]));
+        let item = pr_to_item(pr);
+        assert!(item.latest_comment.is_none());
     }
 
     #[test]

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -21,6 +21,7 @@
     searchQuery: string;
     searchVisible: boolean;
     unreadOnly: boolean;
+    showLatestComment: boolean;
     onRefresh: () => void;
     onMarkAllVisibleAsRead: () => void;
     onShowSettings: () => void;
@@ -49,6 +50,7 @@
     searchQuery = $bindable(),
     searchVisible,
     unreadOnly,
+    showLatestComment,
     onRefresh,
     onMarkAllVisibleAsRead,
     onShowSettings,
@@ -317,7 +319,7 @@
                       {/each}
                     </span>
                   {/if}
-                  {#if notificationsByKey.has(itemKey(item)) && item.latest_comment}
+                  {#if showLatestComment && notificationsByKey.has(itemKey(item)) && item.latest_comment}
                     {@const flat = flattenCommentBody(
                       item.latest_comment.body_text,
                     )}

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { itemKey, relativeTime } from "$lib/list";
+  import { flattenCommentBody, itemKey, relativeTime } from "$lib/list";
   import type {
     NotificationItem,
     RepoGroup,
@@ -316,6 +316,24 @@
                         </span>
                       {/each}
                     </span>
+                  {/if}
+                  {#if notificationsByKey.has(itemKey(item)) && item.latest_comment}
+                    {@const flat = flattenCommentBody(
+                      item.latest_comment.body_text,
+                    )}
+                    {#if flat.length > 0}
+                      <span
+                        class="latest-comment"
+                        title={item.latest_comment.body_text}
+                      >
+                        <span class="latest-comment-clamp">
+                          <span class="latest-comment-author"
+                            >@{item.latest_comment.author}</span
+                          >
+                          {flat}
+                        </span>
+                      </span>
+                    {/if}
                   {/if}
                 </span>
               </button>
@@ -933,5 +951,47 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
+  }
+
+  /* Quote-like preview of the latest unread comment. Only shown for items
+     that still have an active notification thread, so the noise scales with
+     the unread count rather than the entire list. Two lines are clamped via
+     `-webkit-line-clamp` so the line count is bounded but the body wraps
+     naturally instead of cutting mid-word. */
+  /* Outer chrome: padding/border/background only. Padding+overflow on the
+     same element as `-webkit-line-clamp` lets the third line bleed into the
+     padding-bottom region (overflow:hidden clips at the padding-box, not the
+     content-box), which is exactly the artefact users were seeing. */
+  .latest-comment {
+    display: block;
+    margin-top: 6px;
+    padding: 6px 8px 7px;
+    border-left: 2px solid rgba(120, 130, 150, 0.45);
+    background: rgba(120, 130, 150, 0.08);
+    border-radius: 0 4px 4px 0;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    color: var(--muted, #aaa);
+    word-break: break-word;
+    overflow: hidden;
+  }
+
+  /* Inner clamp container: no padding, so its content-box and padding-box
+     coincide. `max-height = 3 line boxes` and `overflow: hidden` together
+     guarantee a hard 3-line cut even when the webkit clamp itself rounds
+     fractionally. */
+  .latest-comment-clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    max-height: calc(1.55em * 3);
+  }
+
+  .latest-comment-author {
+    font-weight: 600;
+    margin-right: 4px;
+    opacity: 0.95;
   }
 </style>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -18,6 +18,7 @@
     refreshMs: number;
     refreshOptions: { value: number; label: string }[];
     notifyEnabled: boolean;
+    showLatestComment: boolean;
     theme: Theme;
     themeOptions: { value: Theme; label: string }[];
     autostartEnabled: boolean | null;
@@ -38,6 +39,7 @@
     onBack: () => void;
     onIntervalChange: (value: number) => void;
     onNotifyChange: (enabled: boolean) => void;
+    onShowLatestCommentChange: (enabled: boolean) => void;
     onThemeChange: (value: Theme) => void;
     onToggleAutostart: (enabled: boolean) => void;
     onSendTestNotification: () => void;
@@ -56,6 +58,7 @@
     refreshMs,
     refreshOptions,
     notifyEnabled,
+    showLatestComment,
     theme,
     themeOptions,
     autostartEnabled,
@@ -76,6 +79,7 @@
     onBack,
     onIntervalChange,
     onNotifyChange,
+    onShowLatestCommentChange,
     onThemeChange,
     onToggleAutostart,
     onSendTestNotification,
@@ -156,6 +160,14 @@
         type="checkbox"
         checked={notifyEnabled}
         onchange={(e) => onNotifyChange(e.currentTarget.checked)}
+      />
+    </label>
+    <label class="setting-row">
+      <span class="setting-label">Show latest comment under unread items</span>
+      <input
+        type="checkbox"
+        checked={showLatestComment}
+        onchange={(e) => onShowLatestCommentChange(e.currentTarget.checked)}
       />
     </label>
     <label class="setting-row">

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -3,6 +3,7 @@ import type { WatchedItem } from "./types";
 import {
   filterBySearch,
   filterVisible,
+  flattenCommentBody,
   groupByRepo,
   itemKey,
   relativeTime,
@@ -25,6 +26,7 @@ function makeItem(
     reviewers: [],
     commenters: [],
     ci_status: null,
+    latest_comment: null,
     ...overrides,
   };
 }
@@ -270,5 +272,29 @@ describe("filterBySearch", () => {
   it("returns empty array when no item matches all tokens", () => {
     const out = filterBySearch(items, "acme nothingmatches");
     expect(out).toEqual([]);
+  });
+});
+
+describe("flattenCommentBody", () => {
+  it("collapses runs of whitespace and embedded newlines", () => {
+    expect(flattenCommentBody("first line\n\nsecond   line\n\tthird")).toBe(
+      "first line second line third",
+    );
+  });
+
+  it("strips fenced code blocks", () => {
+    expect(flattenCommentBody("before\n```ts\ncode()\n```\nafter")).toBe(
+      "before after",
+    );
+  });
+
+  it("suppresses content after an unclosed fence", () => {
+    // Mirrors the Rust side: an unclosed fence still hides everything after
+    // it so a half-rendered code block doesn't leak into the preview.
+    expect(flattenCommentBody("before\n```\ncode")).toBe("before");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(flattenCommentBody("   \n\t  ")).toBe("");
   });
 });

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -19,6 +19,26 @@ export function itemKey(i: {
   return `${i.repo}:${i.kind}:${i.number}`;
 }
 
+/// Flatten a comment body for one-line display in the list: drop fenced-code
+/// blocks (they explode height) and collapse any whitespace run — including
+/// embedded newlines — into a single space. Mirrors the Rust-side
+/// `flatten_comment_body` so the inline preview and the OS notification
+/// excerpt look the same.
+export function flattenCommentBody(body: string): string {
+  let inFence = false;
+  const kept: string[] = [];
+  for (const line of body.split("\n")) {
+    const trimmed = line.replace(/^\s+/, "");
+    if (trimmed.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    kept.push(line);
+  }
+  return kept.join(" ").split(/\s+/).filter(Boolean).join(" ");
+}
+
 export function filterVisible(
   items: WatchedItem[],
   opts: {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -9,6 +9,7 @@ export const PINNED_ITEMS_KEY = "eir.pinnedItems";
 export const WATCHED_ORGS_KEY = "eir.watchedOrgs";
 export const THEME_KEY = "eir.theme";
 export const UNREAD_ONLY_KEY = "eir.unreadOnly";
+export const SHOW_LATEST_COMMENT_KEY = "eir.showLatestComment";
 
 export const DEFAULT_REFRESH_MS = 60_000;
 
@@ -117,4 +118,12 @@ export function loadUnreadOnly(): boolean {
 
 export function persistUnreadOnly(enabled: boolean): void {
   localStorage.setItem(UNREAD_ONLY_KEY, enabled ? "1" : "0");
+}
+
+export function loadShowLatestComment(): boolean {
+  return localStorage.getItem(SHOW_LATEST_COMMENT_KEY) !== "0";
+}
+
+export function persistShowLatestComment(enabled: boolean): void {
+  localStorage.setItem(SHOW_LATEST_COMMENT_KEY, enabled ? "1" : "0");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,14 @@ export type Commenter = {
   avatar_url: string;
 };
 
+export type LatestComment = {
+  author: string;
+  author_avatar: string;
+  body_text: string;
+  created_at: string;
+  url: string;
+};
+
 export type CiStatus = "success" | "pending" | "failure" | "error" | "unknown";
 
 export type WatchedItem = {
@@ -32,6 +40,7 @@ export type WatchedItem = {
   reviewers: Reviewer[];
   commenters: Commenter[];
   ci_status: CiStatus | null;
+  latest_comment: LatestComment | null;
 };
 
 export type NotificationItem = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,7 @@
     loadInterval,
     loadNotify,
     loadPinnedItems,
+    loadShowLatestComment,
     loadTab,
     loadTheme,
     loadUnreadOnly,
@@ -39,6 +40,7 @@
     persistInterval,
     persistNotify,
     persistPinnedItems,
+    persistShowLatestComment,
     persistTab,
     persistTheme,
     persistUnreadOnly,
@@ -90,6 +92,7 @@
   let showingSettings = $state(false);
   let refreshMs = $state<number>(loadInterval());
   let notifyEnabled = $state<boolean>(loadNotify());
+  let showLatestComment = $state<boolean>(loadShowLatestComment());
   let theme = $state<Theme>(loadTheme());
   let systemDark = $state<boolean>(
     window.matchMedia("(prefers-color-scheme: dark)").matches,
@@ -685,6 +688,11 @@
     void pushBackgroundConfig({ notifyEnabled: enabled });
   }
 
+  function onShowLatestCommentChange(enabled: boolean) {
+    showLatestComment = enabled;
+    persistShowLatestComment(enabled);
+  }
+
   function hideItem(id: number) {
     hiddenItems.add(id);
     persistHiddenItems(hiddenItems);
@@ -760,6 +768,7 @@
     version: number;
     refreshMs?: number;
     notifyEnabled?: boolean;
+    showLatestComment?: boolean;
     theme?: Theme;
     excludedRepos?: string[];
     watchedOrgs?: string[];
@@ -773,6 +782,7 @@
       version: SETTINGS_EXPORT_VERSION,
       refreshMs,
       notifyEnabled,
+      showLatestComment,
       theme,
       excludedRepos: [...excludedRepos].sort(),
       watchedOrgs: [...watchedOrgs].sort(),
@@ -848,6 +858,11 @@
     if (typeof data.notifyEnabled === "boolean") {
       onNotifyChange(data.notifyEnabled);
       applied.push("notifications");
+    }
+
+    if (typeof data.showLatestComment === "boolean") {
+      onShowLatestCommentChange(data.showLatestComment);
+      applied.push("latest comment preview");
     }
 
     if (
@@ -1040,6 +1055,7 @@
       {refreshMs}
       refreshOptions={REFRESH_OPTIONS}
       {notifyEnabled}
+      {showLatestComment}
       {theme}
       themeOptions={THEME_OPTIONS}
       {autostartEnabled}
@@ -1060,6 +1076,7 @@
       onBack={() => (showingSettings = false)}
       {onIntervalChange}
       {onNotifyChange}
+      {onShowLatestCommentChange}
       {onThemeChange}
       onToggleAutostart={toggleAutostart}
       onSendTestNotification={sendTestNotification}
@@ -1121,6 +1138,7 @@
       {error}
       {searchVisible}
       {unreadOnly}
+      {showLatestComment}
       bind:searchQuery
       onRefresh={triggerRefresh}
       onMarkAllVisibleAsRead={markAllVisibleAsRead}


### PR DESCRIPTION
## Summary
- GraphQL クエリに PR/Issue の最新コメント (`bodyText` / author / createdAt / url) を載せ、`WatchedItem.latest_comment` として配信
- OS 通知の title を `repo#N: タイトル(60字)`、body を `@author: 本文抜粋(140字)` に変更。コードフェンスは除去、複数件まとまった時は `(+N件)` 付加
- 未読アイテム（通知スレッドが残っているもの）の行内に最新コメントを引用風の枠で 3 行までプレビュー（hover で全文）
- Settings に "Show latest comment under unread items" トグルを追加（デフォルト ON）

## Why
通知だけでは「何のコメントか」がわからずアプリを開く手間が発生していた。タイトル + 本文抜粋を OS 通知に載せ、ポップアップ内でも読めるようにする。プレビューがうるさいユーザ向けに Settings から無効化可。

## Test plan
- [ ] `pnpm tauri dev` で実機確認
  - [ ] PR/Issue にコメント → OS 通知の title が `repo#N: タイトル`、body が `@author: 抜粋` になる
  - [ ] 既読アイテムにはプレビューが出ない
  - [ ] 未読アイテムにのみ引用風のプレビューが出る
  - [ ] 長文コメントが 3 行で clamp され、3 行目末尾に `…`
  - [ ] hover で `title` 属性のフルテキストが見える
  - [ ] Settings の "Show latest comment under unread items" を OFF にするとプレビューが消える、ON で即復帰
  - [ ] 設定が再起動後も保持される
- [x] `cargo test --lib` (85 件)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `pnpm check` (0 errors / 0 warnings)
- [x] `pnpm test` (40 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)