### PR TITLE
feat: add Repo/Recent view-mode toggle for list

### DIFF
--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -4,6 +4,7 @@
     NotificationItem,
     RepoGroup,
     Tab,
+    ViewMode,
     WatchedItem,
   } from "$lib/types";
 
@@ -21,6 +22,7 @@
     searchQuery: string;
     searchVisible: boolean;
     unreadOnly: boolean;
+    viewMode: ViewMode;
     showLatestComment: boolean;
     onRefresh: () => void;
     onMarkAllVisibleAsRead: () => void;
@@ -34,6 +36,7 @@
     onClearSearch: () => void;
     onCloseSearch: () => void;
     onToggleUnreadOnly: () => void;
+    onSetViewMode: (mode: ViewMode) => void;
   };
 
   let {
@@ -50,6 +53,7 @@
     searchQuery = $bindable(),
     searchVisible,
     unreadOnly,
+    viewMode,
     showLatestComment,
     onRefresh,
     onMarkAllVisibleAsRead,
@@ -63,7 +67,13 @@
     onClearSearch,
     onCloseSearch,
     onToggleUnreadOnly,
+    onSetViewMode,
   }: Props = $props();
+
+  const VIEW_MODES: { id: ViewMode; label: string; title: string }[] = [
+    { id: "grouped", label: "Repo", title: "Group by repository" },
+    { id: "recent", label: "Recent", title: "Sort by most recent activity" },
+  ];
 
   function onSearchKeyDown(e: KeyboardEvent) {
     if (e.key === "Escape") {
@@ -156,6 +166,41 @@
       <span class="filter-x" aria-hidden="true">×</span>
     {/if}
   </button>
+  <div
+    class="view-toggle"
+    role="group"
+    aria-label="View mode"
+    title="Toggle list view (R)"
+  >
+    {#each VIEW_MODES as mode (mode.id)}
+      <button
+        class="view-toggle-btn"
+        class:active={viewMode === mode.id}
+        onclick={() => onSetViewMode(mode.id)}
+        aria-pressed={viewMode === mode.id}
+        title={mode.title}
+        aria-label={mode.title}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          {#if mode.id === "grouped"}
+            <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          {:else}
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 7v5l3 2" />
+          {/if}
+        </svg>
+        <span>{mode.label}</span>
+      </button>
+    {/each}
+  </div>
 </div>
 {#if searchVisible || searchQuery !== ""}
   <div class="search" class:active={searchQuery !== ""}>
@@ -204,30 +249,36 @@
   </section>
 {:else}
   <ul class="list" class:dim={loading}>
-    {#each groups as group (group.kind === "pinned" ? "__pinned__" : group.repo)}
-      <li class="group" class:pinned={group.kind === "pinned"}>
-        <div class="group-header" class:pinned-header={group.kind === "pinned"}>
-          <span class="group-repo">
-            {#if group.kind === "pinned"}
-              <svg
-                class="group-pin-icon"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  d="M16 4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v3.8l-2.4 2.4A2 2 0 0 0 5 11.6V13h6v8l1 1 1-1v-8h6v-1.4a2 2 0 0 0-.6-1.4L16 7.8z"
-                />
-              </svg>
-              Pinned
-            {:else}
-              {group.repo}
+    {#each groups as group (group.kind ?? group.repo)}
+      <li
+        class="group"
+        class:pinned={group.kind === "pinned"}
+        class:flat={group.kind === "flat"}
+      >
+        {#if group.kind !== "flat"}
+          <div class="group-header" class:pinned-header={group.kind === "pinned"}>
+            <span class="group-repo">
+              {#if group.kind === "pinned"}
+                <svg
+                  class="group-pin-icon"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M16 4a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v3.8l-2.4 2.4A2 2 0 0 0 5 11.6V13h6v8l1 1 1-1v-8h6v-1.4a2 2 0 0 0-.6-1.4L16 7.8z"
+                  />
+                </svg>
+                Pinned
+              {:else}
+                {group.repo}
+              {/if}
+            </span>
+            {#if group.unreadCount > 0}
+              <span class="group-count">{group.unreadCount}</span>
             {/if}
-          </span>
-          {#if group.unreadCount > 0}
-            <span class="group-count">{group.unreadCount}</span>
-          {/if}
-        </div>
+          </div>
+        {/if}
         <ul class="group-items">
           {#each group.items as item (item.id)}
             <li class="item-row" data-item-id={item.id}>
@@ -249,6 +300,10 @@
                     <span class="title-text">{item.title}</span>
                   </span>
                   <span class="meta">
+                    {#if viewMode === "recent"}
+                      <span class="repo-chip" title={item.repo}>{item.repo}</span>
+                      <span class="sep">·</span>
+                    {/if}
                     <img
                       class="avatar"
                       src={item.author_avatar}
@@ -479,6 +534,55 @@
     font-size: 13px;
     line-height: 1;
     opacity: 0.8;
+  }
+
+  .view-toggle {
+    display: inline-flex;
+    margin-left: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    overflow: hidden;
+    background: none;
+  }
+
+  .view-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.5;
+    border: none;
+    background: none;
+    color: var(--fg-muted);
+    cursor: pointer;
+  }
+
+  .view-toggle-btn:hover {
+    background: var(--hover-bg);
+  }
+
+  .view-toggle-btn.active {
+    background: var(--accent-bg);
+    color: var(--accent);
+  }
+
+  .view-toggle-btn svg {
+    width: 11px;
+    height: 11px;
+    display: block;
+  }
+
+  .repo-chip {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+    color: var(--fg);
+    opacity: 0.85;
   }
 
   .tabs {

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -4,6 +4,7 @@ import {
   filterBySearch,
   filterVisible,
   flattenCommentBody,
+  groupByRecent,
   groupByRepo,
   itemKey,
   relativeTime,
@@ -198,6 +199,84 @@ describe("groupByRepo", () => {
     const groups = groupByRepo(items, (i) => i.id === 1, new Set([1, 2]));
     expect(groups[0].kind).toBe("pinned");
     expect(groups[0].unreadCount).toBe(1);
+  });
+});
+
+describe("groupByRecent", () => {
+  it("returns a single flat group sorted by updated_at desc", () => {
+    const items = [
+      makeItem({
+        id: 1,
+        repo: "a/a",
+        number: 1,
+        updated_at: "2026-04-10T00:00:00Z",
+      }),
+      makeItem({
+        id: 2,
+        repo: "b/b",
+        number: 2,
+        updated_at: "2026-04-19T00:00:00Z",
+      }),
+      makeItem({
+        id: 3,
+        repo: "a/a",
+        number: 3,
+        updated_at: "2026-04-18T00:00:00Z",
+      }),
+    ];
+    const groups = groupByRecent(items, () => false);
+    expect(groups.length).toBe(1);
+    expect(groups[0].kind).toBe("flat");
+    expect(groups[0].items.map((i) => i.id)).toEqual([2, 3, 1]);
+  });
+
+  it("places pinned items in a dedicated top group, flat group with the rest", () => {
+    const items = [
+      makeItem({
+        id: 1,
+        repo: "a/a",
+        number: 1,
+        updated_at: "2026-04-10T00:00:00Z",
+      }),
+      makeItem({
+        id: 2,
+        repo: "b/b",
+        number: 2,
+        updated_at: "2026-04-19T00:00:00Z",
+      }),
+      makeItem({
+        id: 3,
+        repo: "a/a",
+        number: 3,
+        updated_at: "2026-04-18T00:00:00Z",
+      }),
+    ];
+    const groups = groupByRecent(items, () => false, new Set([2]));
+    expect(groups.map((g) => g.kind)).toEqual(["pinned", "flat"]);
+    expect(groups[0].items.map((i) => i.id)).toEqual([2]);
+    expect(groups[1].items.map((i) => i.id)).toEqual([3, 1]);
+  });
+
+  it("counts unread inside the flat group", () => {
+    const items = [
+      makeItem({ id: 1, repo: "a/a", number: 1 }),
+      makeItem({ id: 2, repo: "b/b", number: 2 }),
+      makeItem({ id: 3, repo: "c/c", number: 3 }),
+    ];
+    const unread = new Set([1, 3]);
+    const groups = groupByRecent(items, (i) => unread.has(i.id));
+    expect(groups[0].kind).toBe("flat");
+    expect(groups[0].unreadCount).toBe(2);
+  });
+
+  it("omits the flat group when nothing is left after pinning", () => {
+    const items = [makeItem({ id: 1, repo: "a/a", number: 1 })];
+    const groups = groupByRecent(items, () => false, new Set([1]));
+    expect(groups.map((g) => g.kind)).toEqual(["pinned"]);
+  });
+
+  it("returns no groups for an empty input", () => {
+    expect(groupByRecent([], () => false)).toEqual([]);
   });
 });
 

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -81,24 +81,69 @@ export function filterBySearch(
   });
 }
 
+function splitPinned(
+  items: WatchedItem[],
+  pinnedIds: ReadonlySet<number>,
+): { pinned: WatchedItem[]; rest: WatchedItem[] } {
+  const pinned: WatchedItem[] = [];
+  const rest: WatchedItem[] = [];
+  for (const item of items) {
+    if (pinnedIds.has(item.id)) pinned.push(item);
+    else rest.push(item);
+  }
+  return { pinned, rest };
+}
+
+function makePinnedGroup(
+  pinned: WatchedItem[],
+  isUnread: (i: WatchedItem) => boolean,
+): RepoGroup | null {
+  if (pinned.length === 0) return null;
+  pinned.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  return {
+    repo: "Pinned",
+    items: pinned,
+    mostRecent: pinned[0].updated_at,
+    unreadCount: pinned.filter(isUnread).length,
+    kind: "pinned",
+  };
+}
+
+export function groupByRecent(
+  items: WatchedItem[],
+  isUnread: (i: WatchedItem) => boolean,
+  pinnedIds: ReadonlySet<number> = new Set(),
+): RepoGroup[] {
+  const { pinned, rest } = splitPinned(items, pinnedIds);
+  rest.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+
+  const groups: RepoGroup[] = [];
+  const pinnedGroup = makePinnedGroup(pinned, isUnread);
+  if (pinnedGroup) groups.push(pinnedGroup);
+  if (rest.length > 0) {
+    groups.push({
+      repo: "Recent",
+      items: rest,
+      mostRecent: rest[0].updated_at,
+      unreadCount: rest.filter(isUnread).length,
+      kind: "flat",
+    });
+  }
+  return groups;
+}
+
 export function groupByRepo(
   items: WatchedItem[],
   isUnread: (i: WatchedItem) => boolean,
   pinnedIds: ReadonlySet<number> = new Set(),
 ): RepoGroup[] {
-  const pinned: WatchedItem[] = [];
+  const { pinned, rest } = splitPinned(items, pinnedIds);
+
   const byRepo = new Map<string, WatchedItem[]>();
-  for (const item of items) {
-    if (pinnedIds.has(item.id)) {
-      pinned.push(item);
-      continue;
-    }
+  for (const item of rest) {
     const bucket = byRepo.get(item.repo);
-    if (bucket) {
-      bucket.push(item);
-    } else {
-      byRepo.set(item.repo, [item]);
-    }
+    if (bucket) bucket.push(item);
+    else byRepo.set(item.repo, [item]);
   }
 
   const repoGroups: RepoGroup[] = [];
@@ -113,17 +158,8 @@ export function groupByRepo(
   }
   repoGroups.sort((a, b) => b.mostRecent.localeCompare(a.mostRecent));
 
-  if (pinned.length === 0) return repoGroups;
-
-  pinned.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
-  const pinnedGroup: RepoGroup = {
-    repo: "Pinned",
-    items: pinned,
-    mostRecent: pinned[0].updated_at,
-    unreadCount: pinned.filter(isUnread).length,
-    kind: "pinned",
-  };
-  return [pinnedGroup, ...repoGroups];
+  const pinnedGroup = makePinnedGroup(pinned, isUnread);
+  return pinnedGroup ? [pinnedGroup, ...repoGroups] : repoGroups;
 }
 
 export function repoSuggestionsFrom(

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import type { Tab } from "$lib/types";
+import type { Tab, ViewMode } from "$lib/types";
 
 export const TAB_KEY = "eir.tab";
 export const INTERVAL_KEY = "eir.refreshMs";
@@ -10,6 +10,7 @@ export const WATCHED_ORGS_KEY = "eir.watchedOrgs";
 export const THEME_KEY = "eir.theme";
 export const UNREAD_ONLY_KEY = "eir.unreadOnly";
 export const SHOW_LATEST_COMMENT_KEY = "eir.showLatestComment";
+export const VIEW_MODE_KEY = "eir.viewMode";
 
 export const DEFAULT_REFRESH_MS = 60_000;
 
@@ -126,4 +127,13 @@ export function loadShowLatestComment(): boolean {
 
 export function persistShowLatestComment(enabled: boolean): void {
   localStorage.setItem(SHOW_LATEST_COMMENT_KEY, enabled ? "1" : "0");
+}
+
+export function loadViewMode(): ViewMode {
+  const raw = localStorage.getItem(VIEW_MODE_KEY);
+  return raw === "recent" ? "recent" : "grouped";
+}
+
+export function persistViewMode(value: ViewMode): void {
+  localStorage.setItem(VIEW_MODE_KEY, value);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,10 +56,12 @@ export type NotificationItem = {
 
 export type Tab = "all" | "authored" | "review" | "mentions" | "hidden";
 
+export type ViewMode = "grouped" | "recent";
+
 export type RepoGroup = {
   repo: string;
   items: WatchedItem[];
   mostRecent: string;
   unreadCount: number;
-  kind?: "pinned";
+  kind?: "pinned" | "flat";
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import {
     filterBySearch,
     filterVisible,
+    groupByRecent,
     groupByRepo,
     itemKey,
     repoSuggestionsFrom,
@@ -34,6 +35,7 @@
     loadTab,
     loadTheme,
     loadUnreadOnly,
+    loadViewMode,
     loadWatchedOrgs,
     persistExcludedRepos,
     persistHiddenItems,
@@ -44,10 +46,11 @@
     persistTab,
     persistTheme,
     persistUnreadOnly,
+    persistViewMode,
     persistWatchedOrgs,
     type Theme,
   } from "$lib/storage";
-  import type { NotificationItem, Tab, WatchedItem } from "$lib/types";
+  import type { NotificationItem, Tab, ViewMode, WatchedItem } from "$lib/types";
   import { dispatchShortcut, isEditableTarget, type Shortcut } from "$lib/shortcuts";
   import Auth from "$lib/components/Auth.svelte";
   import ItemList from "$lib/components/ItemList.svelte";
@@ -105,6 +108,7 @@
   let searchQuery = $state("");
   let searchVisible = $state(false);
   let unreadOnly = $state<boolean>(loadUnreadOnly());
+  let viewMode = $state<ViewMode>(loadViewMode());
 
   // The notification plugin's sendNotification() just invokes
   // `new window.Notification(title, options)` under the hood and throws away
@@ -507,6 +511,11 @@
       when: inLoadedPage,
       run: toggleUnreadOnly,
     },
+    {
+      key: "r",
+      when: inLoadedPage,
+      run: toggleViewMode,
+    },
   ];
 
   async function handleGlobalKey(e: KeyboardEvent) {
@@ -752,6 +761,16 @@
     persistUnreadOnly(unreadOnly);
   }
 
+  function setViewMode(mode: ViewMode) {
+    if (mode === viewMode) return;
+    viewMode = mode;
+    persistViewMode(mode);
+  }
+
+  function toggleViewMode() {
+    setViewMode(viewMode === "grouped" ? "recent" : "grouped");
+  }
+
   async function switchTab(tab: Tab) {
     if (tab === activeTab) return;
     activeTab = tab;
@@ -968,7 +987,7 @@
   );
 
   const groups = $derived(
-    groupByRepo(
+    (viewMode === "recent" ? groupByRecent : groupByRepo)(
       visibleItems,
       (i) => notificationsByKey.has(itemKey(i)),
       pinnedItems,
@@ -1138,6 +1157,7 @@
       {error}
       {searchVisible}
       {unreadOnly}
+      {viewMode}
       {showLatestComment}
       bind:searchQuery
       onRefresh={triggerRefresh}
@@ -1152,6 +1172,7 @@
       onClearSearch={clearSearch}
       onCloseSearch={closeSearch}
       onToggleUnreadOnly={toggleUnreadOnly}
+      onSetViewMode={setViewMode}
     />
   {/if}
 </main>


### PR DESCRIPTION
## Summary

Adds a segmented toggle next to "Unread only" that flips the list between the existing repo-grouped view and a flat list sorted by most recent activity.

- Pinned items keep their dedicated top group in either mode
- In Recent mode, the repo name is surfaced in the meta line so the missing group header isn't disorienting
- Choice is persisted (`eir.viewMode` localStorage) and bound to the `R` key (no modifier — doesn't conflict with `Cmd+R` refresh)

## Why

Repo grouping is great when you have a handful of active repos, but when you just want to see "what changed most recently across everything," the headers get in the way. This adds the alternative view without taking grouping away as the default.

## Implementation notes

- New `groupByRecent()` in `src/lib/list.ts`. Extracts `splitPinned` and `makePinnedGroup` helpers so `groupByRepo` and `groupByRecent` share the pinned-extraction logic instead of duplicating it.
- New `RepoGroup.kind: "flat"` variant; `ItemList.svelte` suppresses the group header for flat groups.
- View-toggle buttons are data-driven via a `VIEW_MODES` array + `{#each}`, matching the existing `tabs` pattern.

## Test plan

- [x] `pnpm test` (vitest) — 45 passed, includes 5 new tests for `groupByRecent`
- [x] `pnpm check` (svelte-check) — 0 errors / 0 warnings
- [ ] Manual: toggle between Repo / Recent in the popup
- [ ] Manual: confirm `R` key toggles, `Cmd+R` still refreshes
- [ ] Manual: confirm pinned items stay at the top in both modes
- [ ] Manual: confirm view mode persists across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)