### PR TITLE
feat: include commenter:@me in the Mentions tab

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -113,7 +113,16 @@ fn queries_for_tab(tab: &str, watched_orgs: &[String]) -> Vec<String> {
             "is:open is:pr review-requested:@me archived:false".into(),
             "is:open is:pr reviewed-by:@me archived:false".into(),
         ],
-        "mentions" => vec!["is:open mentions:@me archived:false".into()],
+        // GitHub Search の `mentions:` は本文 (body) しかマッチせず、コメント内
+        // でのメンションは拾えない。`commenter:@me` を OR でユニオンして、
+        // 自分がコメントしている (＝多くの場合メンションへの反応として参加した)
+        // 会話までカバーする。コメント内でメンションされてまだ返事していない
+        // ケースは Search の限界で取りこぼすが、Notifications API を使わない
+        // 範囲ではこれが現実的な近似。
+        "mentions" => vec![
+            "is:open mentions:@me archived:false".into(),
+            "is:open commenter:@me archived:false".into(),
+        ],
         _ => {
             let mut qs = vec![
                 "is:open involves:@me archived:false".into(),
@@ -1295,6 +1304,21 @@ mod tests {
     #[test]
     fn queries_for_tab_review_ignores_watched_orgs() {
         let qs = queries_for_tab("review", &["Lecto-inc".to_string()]);
+        assert_eq!(qs.len(), 2);
+        assert!(qs.iter().all(|q| !q.contains("user:")));
+    }
+
+    #[test]
+    fn queries_for_tab_mentions_includes_mentions_and_commenter() {
+        let qs = queries_for_tab("mentions", &[]);
+        assert_eq!(qs.len(), 2);
+        assert!(qs.iter().any(|q| q.contains("mentions:@me")));
+        assert!(qs.iter().any(|q| q.contains("commenter:@me")));
+    }
+
+    #[test]
+    fn queries_for_tab_mentions_ignores_watched_orgs() {
+        let qs = queries_for_tab("mentions", &["Lecto-inc".to_string()]);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().all(|q| !q.contains("user:")));
     }


### PR DESCRIPTION
## Summary
- Mentions タブに `commenter:@me` を OR でユニオンし、コメントで @-mention された会話のうち自分が反応済みのものまで拾えるようにした
- GitHub Search の `mentions:` 修飾子は **本文 (body) のみ** にマッチする仕様で、コメント内メンションは取りこぼしていた (Web 調査で確認)
- 既存の GraphQL alias-batching に乗せるだけなので HTTP 往復は 1 回のまま

## なぜ
- Mentions タブに「コメントで自分にメンションされた PR」が出ない、というユーザー報告
- GraphQL Search は Web/REST と同じクエリ文法を使うため、`mentions:` 単体ではコメントを覗けない
- Notifications API なら正確に拾えるが REST 専用 + 既読化で消えるという UX 制約があるため、まずは Search だけで賄える近似で前進する

## 仕様変更後の挙動
| 状況 | 拾える? |
|---|---|
| 本文に `@me` がある PR/Issue | ✅ (`mentions:@me`) |
| コメントで `@me` メンションされ自分が返信済 | ✅ (`commenter:@me`) |
| コメントで `@me` メンションされまだ未返信 | ❌ (Search の限界) |

## Test plan
- [x] `cargo test --lib queries_for_tab` — 新規 2 テスト含めて 9 件パス
- [x] `cargo clippy --all-targets -- -D warnings` — warning なし
- [x] `cargo fmt --check` — 差分なし
- [ ] `pnpm tauri dev` で Mentions タブを開き、自分がコメント参加した PR が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)