### PR TITLE
fix: prune cached notifications on mark-as-read

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -139,6 +139,25 @@ impl BackgroundHandle {
         emit_state(app, self);
         update_tray_badge(app, self);
     }
+
+    /// Drop the given thread IDs from the cached notifications. Used by
+    /// `mark_notification_read` so an immediately-following `trigger_refresh`
+    /// doesn't emit a `loading=true` prelude carrying the stale unread set
+    /// (which would briefly re-mark items as unread before the actual fetch
+    /// completes). Also clears the matching diff anchors so the next cycle
+    /// doesn't treat the now-read thread as freshly removed.
+    pub fn remove_notifications(&self, thread_ids: &[u64]) {
+        if thread_ids.is_empty() {
+            return;
+        }
+        let set: HashSet<u64> = thread_ids.iter().copied().collect();
+        self.with_state(|s| {
+            s.notifications.retain(|n| !set.contains(&n.thread_id));
+            for id in &set {
+                s.prev_thread_updated_at.remove(id);
+            }
+        });
+    }
 }
 
 impl Default for BackgroundHandle {

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::auth::{clear_stored_token, AppState};
+use crate::background::BackgroundHandle;
 
 /// Error type for the inner fetch helpers that background tasks and Tauri
 /// commands share. The `is_unauthorized` flag lets callers decide whether to
@@ -993,6 +994,7 @@ pub async fn fetch_notifications(
 pub async fn mark_notification_read(
     thread_id: u64,
     auth: State<'_, Mutex<AppState>>,
+    background: State<'_, BackgroundHandle>,
 ) -> Result<(), String> {
     let octo = build_octo(&auth)?;
 
@@ -1002,7 +1004,15 @@ pub async fn mark_notification_read(
         .mark_as_read(NotificationId(thread_id))
         .await
     {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            // Drop the thread from the worker's cached notifications so any
+            // state-updated emit that races with a follow-up trigger_refresh
+            // (the prelude that flips `loading=true` and re-emits the current
+            // snapshot) doesn't briefly resurrect the unread dot before the
+            // GitHub fetch resolves with the now-read state.
+            background.remove_notifications(&[thread_id]);
+            Ok(())
+        }
         Err(err) => {
             let ge = GithubError::from_octocrab(err);
             if ge.is_unauthorized {


### PR DESCRIPTION
## Summary
- After "Mark all as read", the popup briefly re-flagged every item as unread while the follow-up refresh was in flight.
- Root cause: `mark_notification_read` only hit GitHub — `BackgroundState.notifications` stayed stale, so when the worker's `loading=true` prelude emit fired (triggered by `triggerRefresh()`), it carried the old unread set and overwrote the frontend's optimistic clear until the GitHub fetch resolved.
- Fix: after a successful `mark_as_read`, drop the thread from `BackgroundState.notifications` (and the matching `prev_thread_updated_at` diff anchor) so the prelude emit is consistent with what the user already sees.

## Test plan
- [ ] `cargo check` / `cargo clippy --all-targets -- -D warnings` / `cargo test --lib` (all green locally)
- [ ] `pnpm tauri dev` — click "Mark all as read", confirm items stay marked-as-read through the refresh prelude (no flash back to unread)
- [ ] Single-item read flow (click on a notification): still marks as read, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)