### PR TITLE
feat: PR/Issue include toggles + per-repo overrides

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -75,12 +75,38 @@ pub struct BackgroundState {
 
     pub tab: Tab,
     pub watched_orgs: Vec<String>,
-    pub excluded_repos: HashSet<String>,
+    pub repo_settings: HashMap<String, RepoSetting>,
     pub hidden_items: HashSet<u64>,
     pub notify_enabled: bool,
     pub interval_ms: u64,
     pub include_prs: bool,
     pub include_issues: bool,
+}
+
+/// Per-repository override of which item kinds the user wants to see.
+/// `{prs: true, issues: true}` is the default and is never stored —
+/// repos without an override fall through to the global Include toggles.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RepoSetting {
+    pub prs: bool,
+    pub issues: bool,
+}
+
+/// Decide whether an item should be hidden by its repo's override. Items
+/// from repos without an override are never suppressed here — the global
+/// Include toggles already narrowed the fetch.
+pub(crate) fn suppressed_by_repo(
+    item: &WatchedItem,
+    repo_settings: &HashMap<String, RepoSetting>,
+) -> bool {
+    let Some(s) = repo_settings.get(&item.repo) else {
+        return false;
+    };
+    match item.kind {
+        "pr" => !s.prs,
+        "issue" => !s.issues,
+        _ => false,
+    }
 }
 
 impl BackgroundState {
@@ -201,10 +227,9 @@ fn update_tray_badge(app: &AppHandle, handle: &BackgroundHandle) {
             .iter()
             .filter_map(|n| n.number.map(|num| item_key(&n.repo, n.kind, num)))
             .collect();
-        let visible = s
-            .items
-            .iter()
-            .filter(|i| !s.hidden_items.contains(&i.id) && !s.excluded_repos.contains(&i.repo));
+        let visible = s.items.iter().filter(|i| {
+            !s.hidden_items.contains(&i.id) && !suppressed_by_repo(i, &s.repo_settings)
+        });
         let mut count = 0u32;
         let mut has_unread = false;
         for i in visible {
@@ -381,6 +406,7 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     let (
         tab,
         watched_orgs,
+        repo_settings,
         has_loaded_once,
         prev_items,
         prev_threads,
@@ -393,6 +419,7 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
         (
             s.tab,
             s.watched_orgs.clone(),
+            s.repo_settings.clone(),
             s.has_loaded_once,
             std::mem::take(&mut s.prev_items),
             std::mem::take(&mut s.prev_thread_updated_at),
@@ -427,6 +454,7 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
             &octo,
             tab.as_query_key(),
             &watched_orgs,
+            &repo_settings,
             include_prs,
             include_issues,
         ),
@@ -710,7 +738,7 @@ pub fn trigger_refresh(handle: tauri::State<'_, BackgroundHandle>) {
 pub struct BackgroundConfig {
     pub tab: Option<Tab>,
     pub watched_orgs: Option<Vec<String>>,
-    pub excluded_repos: Option<Vec<String>>,
+    pub repo_settings: Option<HashMap<String, RepoSetting>>,
     pub hidden_items: Option<Vec<u64>>,
     pub notify_enabled: Option<bool>,
     pub interval_ms: Option<u64>,
@@ -755,10 +783,24 @@ fn apply_background_config(s: &mut BackgroundState, config: BackgroundConfig) ->
             trigger = true;
         }
     }
-    if let Some(excluded) = config.excluded_repos {
-        let next: HashSet<String> = excluded.into_iter().collect();
-        if next != s.excluded_repos {
-            s.excluded_repos = next;
+    if let Some(next) = config.repo_settings {
+        // {prs:true, issues:true} entries are the implicit default and would
+        // otherwise force a generation bump on every round-trip through the UI.
+        let next: HashMap<String, RepoSetting> = next
+            .into_iter()
+            .filter(|(_, s)| !(s.prs && s.issues))
+            .collect();
+        if next != s.repo_settings {
+            // A widening override (global OFF + repo ON) changes the GraphQL
+            // query, not just the client-side filter — invalidate anchors and
+            // refetch. Pure narrowing changes pay this cost too; the savings
+            // weren't worth the extra book-keeping at human cadence.
+            s.repo_settings = next;
+            s.has_loaded_once = false;
+            s.prev_items.clear();
+            s.prev_thread_updated_at.clear();
+            s.config_generation = s.config_generation.wrapping_add(1);
+            trigger = true;
             badge_dirty = true;
         }
     }
@@ -1210,7 +1252,7 @@ mod apply_background_config_tests {
         BackgroundConfig {
             tab: Some(tab),
             watched_orgs: None,
-            excluded_repos: None,
+            repo_settings: None,
             hidden_items: None,
             notify_enabled: None,
             interval_ms: None,
@@ -1223,7 +1265,7 @@ mod apply_background_config_tests {
         BackgroundConfig {
             tab: None,
             watched_orgs: None,
-            excluded_repos: None,
+            repo_settings: None,
             hidden_items: None,
             notify_enabled: None,
             interval_ms: None,
@@ -1295,24 +1337,94 @@ mod apply_background_config_tests {
     }
 
     #[test]
-    fn excluded_repos_change_does_not_bump_generation() {
-        // excluded_repos is a frontend-side filter and doesn't change the
-        // worker's fetch — bumping generation here would needlessly throw
-        // away a perfectly valid diff anchor on every settings tweak.
+    fn repo_settings_change_bumps_generation_and_marks_badge_dirty() {
+        // A widening override changes the GraphQL query, so anchors are stale
+        // and the badge composition has shifted.
         let mut s = BackgroundState::new();
         seed_loaded_state(&mut s, Tab::All);
         let before = s.config_generation;
 
+        let mut next = HashMap::new();
+        next.insert(
+            "o/r".to_string(),
+            RepoSetting {
+                prs: true,
+                issues: false,
+            },
+        );
         let (trigger, badge_dirty) = apply_background_config(
             &mut s,
             BackgroundConfig {
-                excluded_repos: Some(vec!["o/r".into()]),
+                repo_settings: Some(next),
+                ..empty_config()
+            },
+        );
+
+        assert!(trigger);
+        assert!(badge_dirty);
+        assert_ne!(s.config_generation, before);
+        assert!(s.prev_items.is_empty());
+    }
+
+    #[test]
+    fn repo_settings_default_entries_are_pruned() {
+        // {prs:true, issues:true} is the implicit default and must not survive
+        // a round-trip — otherwise it would bump the generation for a no-op.
+        let mut s = BackgroundState::new();
+        seed_loaded_state(&mut s, Tab::All);
+        let before = s.config_generation;
+
+        let mut next = HashMap::new();
+        next.insert(
+            "o/r".to_string(),
+            RepoSetting {
+                prs: true,
+                issues: true,
+            },
+        );
+        let (trigger, _) = apply_background_config(
+            &mut s,
+            BackgroundConfig {
+                repo_settings: Some(next),
                 ..empty_config()
             },
         );
 
         assert!(!trigger);
-        assert!(badge_dirty);
+        assert_eq!(s.config_generation, before);
+        assert!(s.repo_settings.is_empty());
+    }
+
+    #[test]
+    fn repo_settings_no_op_does_not_bump_generation() {
+        let mut s = BackgroundState::new();
+        seed_loaded_state(&mut s, Tab::All);
+        s.repo_settings.insert(
+            "o/r".to_string(),
+            RepoSetting {
+                prs: false,
+                issues: true,
+            },
+        );
+        let before = s.config_generation;
+
+        let mut next = HashMap::new();
+        next.insert(
+            "o/r".to_string(),
+            RepoSetting {
+                prs: false,
+                issues: true,
+            },
+        );
+        let (trigger, _) = apply_background_config(
+            &mut s,
+            BackgroundConfig {
+                repo_settings: Some(next),
+                ..empty_config()
+            },
+        );
+
+        assert!(!trigger);
         assert_eq!(s.config_generation, before);
     }
 

--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -79,6 +79,8 @@ pub struct BackgroundState {
     pub hidden_items: HashSet<u64>,
     pub notify_enabled: bool,
     pub interval_ms: u64,
+    pub include_prs: bool,
+    pub include_issues: bool,
 }
 
 impl BackgroundState {
@@ -86,6 +88,8 @@ impl BackgroundState {
         Self {
             notify_enabled: true,
             interval_ms: DEFAULT_INTERVAL_MS,
+            include_prs: true,
+            include_issues: true,
             ..Default::default()
         }
     }
@@ -374,19 +378,30 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     // before any await so the state stays contended-free while fetching.
     // `generation` lets the write-back detect a tab/orgs change that landed
     // mid-cycle and discard stale anchors.
-    let (tab, watched_orgs, has_loaded_once, prev_items, prev_threads, notify_enabled, generation) =
-        handle.with_state(|s| {
-            s.loading = true;
-            (
-                s.tab,
-                s.watched_orgs.clone(),
-                s.has_loaded_once,
-                std::mem::take(&mut s.prev_items),
-                std::mem::take(&mut s.prev_thread_updated_at),
-                s.notify_enabled,
-                s.config_generation,
-            )
-        });
+    let (
+        tab,
+        watched_orgs,
+        has_loaded_once,
+        prev_items,
+        prev_threads,
+        notify_enabled,
+        generation,
+        include_prs,
+        include_issues,
+    ) = handle.with_state(|s| {
+        s.loading = true;
+        (
+            s.tab,
+            s.watched_orgs.clone(),
+            s.has_loaded_once,
+            std::mem::take(&mut s.prev_items),
+            std::mem::take(&mut s.prev_thread_updated_at),
+            s.notify_enabled,
+            s.config_generation,
+            s.include_prs,
+            s.include_issues,
+        )
+    });
     emit_state(app, handle);
 
     let octo = match build_octocrab(&token) {
@@ -408,7 +423,13 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     // The partial-emit callbacks skip the write when `config_generation`
     // has advanced so old-tab items don't briefly flash into the new-tab UI.
     let (items_res, notifs_res) = drive_progressive_fetches(
-        fetch_watched_with(&octo, tab.as_query_key(), &watched_orgs),
+        fetch_watched_with(
+            &octo,
+            tab.as_query_key(),
+            &watched_orgs,
+            include_prs,
+            include_issues,
+        ),
         fetch_notifications_with(&octo),
         |items| {
             let applied = handle.with_state(|s| {
@@ -693,6 +714,8 @@ pub struct BackgroundConfig {
     pub hidden_items: Option<Vec<u64>>,
     pub notify_enabled: Option<bool>,
     pub interval_ms: Option<u64>,
+    pub include_prs: Option<bool>,
+    pub include_issues: Option<bool>,
 }
 
 /// Apply a config patch to the background state. Pulled out of the Tauri
@@ -751,6 +774,24 @@ fn apply_background_config(s: &mut BackgroundState, config: BackgroundConfig) ->
     }
     if let Some(ms) = config.interval_ms {
         s.interval_ms = ms.max(MIN_INTERVAL_MS);
+    }
+    // include_prs/include_issues change the search query — treat them like
+    // tab/watched_orgs: invalidate the diff anchors and bump the generation
+    // so an in-flight cycle's write-back can detect the staleness. Refuse a
+    // patch that would leave both off; the frontend already guards but a
+    // malformed import shouldn't strand the worker with nothing to fetch.
+    let next_include_prs = config.include_prs.unwrap_or(s.include_prs);
+    let next_include_issues = config.include_issues.unwrap_or(s.include_issues);
+    let include_dirty =
+        next_include_prs != s.include_prs || next_include_issues != s.include_issues;
+    if (next_include_prs || next_include_issues) && include_dirty {
+        s.include_prs = next_include_prs;
+        s.include_issues = next_include_issues;
+        s.has_loaded_once = false;
+        s.prev_items.clear();
+        s.prev_thread_updated_at.clear();
+        s.config_generation = s.config_generation.wrapping_add(1);
+        trigger = true;
     }
     (trigger, badge_dirty)
 }
@@ -1173,6 +1214,21 @@ mod apply_background_config_tests {
             hidden_items: None,
             notify_enabled: None,
             interval_ms: None,
+            include_prs: None,
+            include_issues: None,
+        }
+    }
+
+    fn empty_config() -> BackgroundConfig {
+        BackgroundConfig {
+            tab: None,
+            watched_orgs: None,
+            excluded_repos: None,
+            hidden_items: None,
+            notify_enabled: None,
+            interval_ms: None,
+            include_prs: None,
+            include_issues: None,
         }
     }
 
@@ -1212,12 +1268,8 @@ mod apply_background_config_tests {
         let (trigger, _) = apply_background_config(
             &mut s,
             BackgroundConfig {
-                tab: None,
                 watched_orgs: Some(vec!["acme".into()]),
-                excluded_repos: None,
-                hidden_items: None,
-                notify_enabled: None,
-                interval_ms: None,
+                ..empty_config()
             },
         );
 
@@ -1254,18 +1306,89 @@ mod apply_background_config_tests {
         let (trigger, badge_dirty) = apply_background_config(
             &mut s,
             BackgroundConfig {
-                tab: None,
-                watched_orgs: None,
                 excluded_repos: Some(vec!["o/r".into()]),
-                hidden_items: None,
-                notify_enabled: None,
-                interval_ms: None,
+                ..empty_config()
             },
         );
 
         assert!(!trigger);
         assert!(badge_dirty);
         assert_eq!(s.config_generation, before);
+    }
+
+    #[test]
+    fn include_toggle_change_bumps_generation() {
+        // Same race story as tab / watched_orgs: include_prs / include_issues
+        // change the GraphQL query, so an in-flight cycle's anchors are now
+        // stale.
+        let mut s = BackgroundState::new();
+        seed_loaded_state(&mut s, Tab::All);
+        let before = s.config_generation;
+
+        let (trigger, _) = apply_background_config(
+            &mut s,
+            BackgroundConfig {
+                include_prs: Some(true),
+                include_issues: Some(false),
+                ..empty_config()
+            },
+        );
+
+        assert!(trigger);
+        assert!(s.include_prs);
+        assert!(!s.include_issues);
+        assert!(!s.has_loaded_once);
+        assert!(s.prev_items.is_empty());
+        assert_ne!(s.config_generation, before);
+    }
+
+    #[test]
+    fn include_toggle_no_op_does_not_bump_generation() {
+        // Pushing the same flags back must not invalidate anchors —
+        // e.g. importing settings that match current values shouldn't
+        // wipe the diff history.
+        let mut s = BackgroundState::new();
+        seed_loaded_state(&mut s, Tab::All);
+        let before = s.config_generation;
+
+        let (trigger, _) = apply_background_config(
+            &mut s,
+            BackgroundConfig {
+                include_prs: Some(true),
+                include_issues: Some(true),
+                ..empty_config()
+            },
+        );
+
+        assert!(!trigger);
+        assert_eq!(s.config_generation, before);
+        assert!(!s.prev_items.is_empty());
+    }
+
+    #[test]
+    fn include_toggle_both_off_is_rejected() {
+        // The frontend already prevents this via the disabled checkbox, but
+        // a malformed import shouldn't strand the worker with nothing to
+        // query — silently keep the previous flags instead.
+        let mut s = BackgroundState::new();
+        seed_loaded_state(&mut s, Tab::All);
+        let before_prs = s.include_prs;
+        let before_issues = s.include_issues;
+        let before_gen = s.config_generation;
+
+        let (trigger, _) = apply_background_config(
+            &mut s,
+            BackgroundConfig {
+                include_prs: Some(false),
+                include_issues: Some(false),
+                ..empty_config()
+            },
+        );
+
+        assert!(!trigger);
+        assert_eq!(s.include_prs, before_prs);
+        assert_eq!(s.include_issues, before_issues);
+        assert_eq!(s.config_generation, before_gen);
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use octocrab::models::NotificationId;
@@ -5,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::auth::{clear_stored_token, AppState};
-use crate::background::BackgroundHandle;
+use crate::background::{BackgroundHandle, RepoSetting};
 
 /// Error type for the inner fetch helpers that background tasks and Tauri
 /// commands share. The `is_unauthorized` flag lets callers decide whether to
@@ -116,14 +117,83 @@ fn kind_prefixes(include_prs: bool, include_issues: bool) -> Vec<&'static str> {
     }
 }
 
-fn queries_for_tab(
-    tab: &str,
-    watched_orgs: &[String],
+/// Cap on the number of widening repos we splice into a single GraphQL
+/// request. GitHub's search rate limit charges per `search` node, and the
+/// alias batching has practical complexity limits well below this — so a
+/// runaway repo_settings (corrupted import, malicious paste) can't cost us
+/// the whole rate budget in one tick. Anything past the cap is silently
+/// skipped; the user can split their overrides if they really need more.
+const MAX_WIDENING_REPOS: usize = 25;
+
+/// `[A-Za-z0-9_-]` per GitHub's login rules. Used to defend against an
+/// arbitrary string sneaking out of a `user:` / `repo:` qualifier.
+fn is_login_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_')
+}
+
+fn sanitize_login(s: &str) -> String {
+    s.chars().filter(|c| is_login_char(*c)).collect()
+}
+
+fn is_valid_repo_name(s: &str) -> bool {
+    s.contains('/')
+        && s.chars()
+            .all(|c| is_login_char(c) || matches!(c, '.' | '/'))
+}
+
+/// Repo-level overrides that **widen** the global Include settings: a repo
+/// the user opted into for a kind the global toggle excludes. Implemented
+/// as extra `is:<kind> repo:<owner>/<name>` aliases on the same GraphQL
+/// request — no extra HTTP round-trip. Narrowing-only overrides are handled
+/// by the client-side filter and don't pass through here.
+fn widening_queries(
+    repo_settings: &HashMap<String, RepoSetting>,
     include_prs: bool,
     include_issues: bool,
 ) -> Vec<String> {
+    // Sort by repo name first so the cap selects deterministically — the
+    // result also feeds merge_search_results, which dedupes by id and is
+    // sensitive to alias ordering for tie-breaking.
+    let mut entries: Vec<(&String, &RepoSetting)> = repo_settings.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut qs = Vec::new();
+    let mut widened_repos = 0usize;
+    for (repo, s) in entries {
+        if !is_valid_repo_name(repo) {
+            continue;
+        }
+        let wants_pr = s.prs && !include_prs;
+        let wants_issue = s.issues && !include_issues;
+        if !(wants_pr || wants_issue) {
+            continue;
+        }
+        if widened_repos >= MAX_WIDENING_REPOS {
+            break;
+        }
+        widened_repos += 1;
+        if wants_pr {
+            qs.push(format!("is:open is:pr repo:{repo} archived:false"));
+        }
+        if wants_issue {
+            qs.push(format!("is:open is:issue repo:{repo} archived:false"));
+        }
+    }
+    qs
+}
+
+fn queries_for_tab(
+    tab: &str,
+    watched_orgs: &[String],
+    repo_settings: &HashMap<String, RepoSetting>,
+    include_prs: bool,
+    include_issues: bool,
+) -> Vec<String> {
+    let widening = widening_queries(repo_settings, include_prs, include_issues);
     if !include_prs && !include_issues {
-        return Vec::new();
+        // Both globals off: widening is the only thing left, and skipping it
+        // here avoids hitting kind_prefixes' `unreachable!`.
+        return widening;
     }
     let kinds = kind_prefixes(include_prs, include_issues);
     match tab {
@@ -131,16 +201,10 @@ fn queries_for_tab(
             .iter()
             .map(|k| format!("is:open {k}author:@me archived:false"))
             .collect(),
-        // Two queries unioned via the GraphQL alias batching in `fetch_watched`:
-        // `review-requested` drops a PR out once you submit any review, so the
-        // tab used to "empty itself" after commenting/approving. Adding
-        // `reviewed-by` keeps PRs you've been assigned to — and touched —
-        // visible until they're closed.
-        //
-        // Review semantics are PR-only (issues have no review system), so this
-        // tab is empty when PRs are excluded — let the user see "nothing here"
-        // rather than firing a query that GitHub would silently return zero
-        // results for.
+        // `review-requested` drops a PR out once you submit any review, so
+        // unioning `reviewed-by` keeps PRs you've already touched visible
+        // until they're closed. Review semantics are PR-only — issues have
+        // no review system, so the tab is empty when PRs are excluded.
         "review" => {
             if !include_prs {
                 return Vec::new();
@@ -174,12 +238,7 @@ fn queries_for_tab(
                 qs.push(format!("is:open {k}user:@me archived:false"));
             }
             for org in watched_orgs {
-                // Allow-list characters to avoid breaking out of the
-                // qualifier. GitHub logins are [A-Za-z0-9-] only.
-                let clean: String = org
-                    .chars()
-                    .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
-                    .collect();
+                let clean = sanitize_login(org);
                 if clean.is_empty() {
                     continue;
                 }
@@ -187,6 +246,10 @@ fn queries_for_tab(
                     qs.push(format!("is:open {k}user:{clean} archived:false"));
                 }
             }
+            // Per-tab lenses (authored / review / mentions) intentionally
+            // skip widening — they're already opinionated and a repo override
+            // there would surface items the user didn't ask for.
+            qs.extend(widening);
             qs
         }
     }
@@ -705,10 +768,17 @@ pub async fn fetch_watched_with(
     octo: &octocrab::Octocrab,
     tab: &str,
     watched_orgs: &[String],
+    repo_settings: &HashMap<String, RepoSetting>,
     include_prs: bool,
     include_issues: bool,
 ) -> Result<Vec<WatchedItem>, GithubError> {
-    let queries = queries_for_tab(tab, watched_orgs, include_prs, include_issues);
+    let queries = queries_for_tab(
+        tab,
+        watched_orgs,
+        repo_settings,
+        include_prs,
+        include_issues,
+    );
     // No query templates for this combo (e.g. Review tab with PRs off, or a
     // both-off config that slipped past the frontend guard). Skipping the
     // GraphQL call keeps `build_search_query(0)` from producing an empty
@@ -756,15 +826,17 @@ pub async fn fetch_watched_with(
 pub async fn fetch_watched(
     tab: String,
     watched_orgs: Option<Vec<String>>,
+    repo_settings: Option<HashMap<String, RepoSetting>>,
     include_prs: Option<bool>,
     include_issues: Option<bool>,
     auth: State<'_, Mutex<AppState>>,
 ) -> Result<Vec<WatchedItem>, String> {
     let octo = build_octo(&auth)?;
     let orgs = watched_orgs.unwrap_or_default();
+    let settings = repo_settings.unwrap_or_default();
     let prs = include_prs.unwrap_or(true);
     let issues = include_issues.unwrap_or(true);
-    match fetch_watched_with(&octo, &tab, &orgs, prs, issues).await {
+    match fetch_watched_with(&octo, &tab, &orgs, &settings, prs, issues).await {
         Ok(items) => Ok(items),
         Err(err) => {
             if err.is_unauthorized {
@@ -1339,6 +1411,24 @@ mod tests {
         assert!(!item.is_draft);
     }
 
+    /// Test-only wrapper that pins `repo_settings` to an empty map so the
+    /// existing query coverage stays focused on the (tab, watched_orgs,
+    /// include_*) axes. Per-repo widening has dedicated tests below.
+    fn queries_for_tab(
+        tab: &str,
+        watched_orgs: &[String],
+        include_prs: bool,
+        include_issues: bool,
+    ) -> Vec<String> {
+        super::queries_for_tab(
+            tab,
+            watched_orgs,
+            &HashMap::new(),
+            include_prs,
+            include_issues,
+        )
+    }
+
     #[test]
     fn queries_for_tab_all_includes_involves_and_user_self() {
         let qs = queries_for_tab("all", &[], true, true);
@@ -1473,6 +1563,119 @@ mod tests {
         let qs = queries_for_tab("mentions", &[], false, true);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().all(|q| q.contains("is:issue ")));
+    }
+
+    fn repo_settings_with(pairs: &[(&str, bool, bool)]) -> HashMap<String, RepoSetting> {
+        pairs
+            .iter()
+            .map(|(repo, prs, issues)| {
+                (
+                    repo.to_string(),
+                    RepoSetting {
+                        prs: *prs,
+                        issues: *issues,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn widening_adds_issue_query_when_global_issues_off_and_repo_issues_on() {
+        let settings = repo_settings_with(&[("Lecto-inc/primeape", false, true)]);
+        let qs = super::queries_for_tab("all", &[], &settings, true, false);
+        assert!(qs
+            .iter()
+            .any(|q| q == "is:open is:issue repo:Lecto-inc/primeape archived:false"));
+    }
+
+    #[test]
+    fn widening_adds_pr_query_when_global_prs_off_and_repo_prs_on() {
+        let settings = repo_settings_with(&[("Lecto-inc/primeape", true, false)]);
+        let qs = super::queries_for_tab("all", &[], &settings, false, true);
+        assert!(qs
+            .iter()
+            .any(|q| q == "is:open is:pr repo:Lecto-inc/primeape archived:false"));
+    }
+
+    #[test]
+    fn widening_skipped_when_global_already_covers_the_kind() {
+        // Issue ON globally + repo Issue ON is the default state; the repo
+        // entry exists in `repo_settings` (because PR is OFF), but we mustn't
+        // emit a redundant `is:issue repo:foo` query — `involves:@me` /
+        // `user:@me` / watched_orgs already cover it, plus the client-side
+        // filter handles the PR-OFF half.
+        let settings = repo_settings_with(&[("Lecto-inc/primeape", false, true)]);
+        let qs = super::queries_for_tab("all", &[], &settings, true, true);
+        assert!(!qs.iter().any(|q| q.contains("repo:Lecto-inc/primeape")));
+    }
+
+    #[test]
+    fn widening_works_when_both_globals_off() {
+        // global both-off is normally a "fetch nothing" state, but a repo
+        // override that widens us back in must still produce a query —
+        // otherwise the user can't carve out a single repo while hiding
+        // everything else.
+        let settings = repo_settings_with(&[("foo/bar", true, true)]);
+        let qs = super::queries_for_tab("all", &[], &settings, false, false);
+        assert_eq!(qs.len(), 2);
+        assert!(qs
+            .iter()
+            .any(|q| q == "is:open is:pr repo:foo/bar archived:false"));
+        assert!(qs
+            .iter()
+            .any(|q| q == "is:open is:issue repo:foo/bar archived:false"));
+    }
+
+    #[test]
+    fn widening_skips_malformed_repo() {
+        // "no-slash" or shell-meta chars get filtered defensively — a stale
+        // import shouldn't break out of the qualifier.
+        let settings = repo_settings_with(&[
+            ("no-slash", true, true),
+            ("bad repo!", true, true),
+            ("good/repo", true, true),
+        ]);
+        let qs = super::widening_queries(&settings, false, false);
+        assert_eq!(qs.len(), 2);
+        assert!(qs
+            .iter()
+            .all(|q| q.contains("repo:good/repo") || q.is_empty()));
+    }
+
+    #[test]
+    fn widening_caps_at_max_repos() {
+        // A pathological repo_settings (corrupted import or malicious paste)
+        // shouldn't be allowed to blow out the GraphQL query's complexity
+        // budget. Anything past MAX_WIDENING_REPOS is silently dropped.
+        let mut settings = HashMap::new();
+        for i in 0..(super::MAX_WIDENING_REPOS + 10) {
+            settings.insert(
+                format!("owner/repo{i:03}"),
+                RepoSetting {
+                    prs: true,
+                    issues: true,
+                },
+            );
+        }
+        let qs = super::widening_queries(&settings, false, false);
+        // Each capped repo contributes 2 aliases (is:pr + is:issue).
+        assert_eq!(qs.len(), super::MAX_WIDENING_REPOS * 2);
+    }
+
+    #[test]
+    fn widening_does_not_apply_to_non_all_tabs() {
+        // The per-tab lenses (authored / review / mentions) are already
+        // opinionated about what to surface — repo widening would inject
+        // items the user didn't ask for under that lens.
+        let settings = repo_settings_with(&[("foo/bar", true, true)]);
+        for tab in ["authored", "review", "mentions"] {
+            let qs = super::queries_for_tab(tab, &[], &settings, true, true);
+            assert!(
+                qs.iter().all(|q| !q.contains("repo:foo/bar")),
+                "{tab} unexpectedly inherited widening"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -102,33 +102,77 @@ pub struct WatchedItem {
     pub latest_comment: Option<LatestComment>,
 }
 
-fn queries_for_tab(tab: &str, watched_orgs: &[String]) -> Vec<String> {
+/// Build the GraphQL `is:pr` / `is:issue` prefix list to splice into each
+/// query template. With both kinds enabled we want one unprefixed query so
+/// GitHub returns both types in a single search; with exactly one enabled we
+/// add the matching narrowing prefix. The both-off case is filtered at the
+/// caller, so `unreachable!` rather than producing a malformed query.
+fn kind_prefixes(include_prs: bool, include_issues: bool) -> Vec<&'static str> {
+    match (include_prs, include_issues) {
+        (true, true) => vec![""],
+        (true, false) => vec!["is:pr "],
+        (false, true) => vec!["is:issue "],
+        (false, false) => unreachable!("caller must short-circuit when both kinds are off"),
+    }
+}
+
+fn queries_for_tab(
+    tab: &str,
+    watched_orgs: &[String],
+    include_prs: bool,
+    include_issues: bool,
+) -> Vec<String> {
+    if !include_prs && !include_issues {
+        return Vec::new();
+    }
+    let kinds = kind_prefixes(include_prs, include_issues);
     match tab {
-        "authored" => vec!["is:open is:pr author:@me archived:false".into()],
+        "authored" => kinds
+            .iter()
+            .map(|k| format!("is:open {k}author:@me archived:false"))
+            .collect(),
         // Two queries unioned via the GraphQL alias batching in `fetch_watched`:
         // `review-requested` drops a PR out once you submit any review, so the
         // tab used to "empty itself" after commenting/approving. Adding
         // `reviewed-by` keeps PRs you've been assigned to — and touched —
         // visible until they're closed.
-        "review" => vec![
-            "is:open is:pr review-requested:@me archived:false".into(),
-            "is:open is:pr reviewed-by:@me archived:false".into(),
-        ],
+        //
+        // Review semantics are PR-only (issues have no review system), so this
+        // tab is empty when PRs are excluded — let the user see "nothing here"
+        // rather than firing a query that GitHub would silently return zero
+        // results for.
+        "review" => {
+            if !include_prs {
+                return Vec::new();
+            }
+            vec![
+                "is:open is:pr review-requested:@me archived:false".into(),
+                "is:open is:pr reviewed-by:@me archived:false".into(),
+            ]
+        }
         // GitHub Search の `mentions:` は本文 (body) しかマッチせず、コメント内
         // でのメンションは拾えない。`commenter:@me` を OR でユニオンして、
         // 自分がコメントしている (＝多くの場合メンションへの反応として参加した)
         // 会話までカバーする。コメント内でメンションされてまだ返事していない
         // ケースは Search の限界で取りこぼすが、Notifications API を使わない
         // 範囲ではこれが現実的な近似。
-        "mentions" => vec![
-            "is:open mentions:@me archived:false".into(),
-            "is:open commenter:@me archived:false".into(),
-        ],
+        "mentions" => kinds
+            .iter()
+            .flat_map(|k| {
+                [
+                    format!("is:open {k}mentions:@me archived:false"),
+                    format!("is:open {k}commenter:@me archived:false"),
+                ]
+            })
+            .collect(),
         _ => {
-            let mut qs = vec![
-                "is:open involves:@me archived:false".into(),
-                "is:open is:pr user:@me archived:false".into(),
-            ];
+            let mut qs: Vec<String> = Vec::new();
+            for k in &kinds {
+                qs.push(format!("is:open {k}involves:@me archived:false"));
+            }
+            for k in &kinds {
+                qs.push(format!("is:open {k}user:@me archived:false"));
+            }
             for org in watched_orgs {
                 // Allow-list characters to avoid breaking out of the
                 // qualifier. GitHub logins are [A-Za-z0-9-] only.
@@ -139,7 +183,9 @@ fn queries_for_tab(tab: &str, watched_orgs: &[String]) -> Vec<String> {
                 if clean.is_empty() {
                     continue;
                 }
-                qs.push(format!("is:open is:pr user:{clean} archived:false"));
+                for k in &kinds {
+                    qs.push(format!("is:open {k}user:{clean} archived:false"));
+                }
             }
             qs
         }
@@ -659,8 +705,17 @@ pub async fn fetch_watched_with(
     octo: &octocrab::Octocrab,
     tab: &str,
     watched_orgs: &[String],
+    include_prs: bool,
+    include_issues: bool,
 ) -> Result<Vec<WatchedItem>, GithubError> {
-    let queries = queries_for_tab(tab, watched_orgs);
+    let queries = queries_for_tab(tab, watched_orgs, include_prs, include_issues);
+    // No query templates for this combo (e.g. Review tab with PRs off, or a
+    // both-off config that slipped past the frontend guard). Skipping the
+    // GraphQL call keeps `build_search_query(0)` from producing an empty
+    // alias list, which GitHub rejects as a syntax error.
+    if queries.is_empty() {
+        return Ok(Vec::new());
+    }
     let query_str = build_search_query(queries.len());
     let variables: serde_json::Map<String, serde_json::Value> = queries
         .iter()
@@ -701,11 +756,15 @@ pub async fn fetch_watched_with(
 pub async fn fetch_watched(
     tab: String,
     watched_orgs: Option<Vec<String>>,
+    include_prs: Option<bool>,
+    include_issues: Option<bool>,
     auth: State<'_, Mutex<AppState>>,
 ) -> Result<Vec<WatchedItem>, String> {
     let octo = build_octo(&auth)?;
     let orgs = watched_orgs.unwrap_or_default();
-    match fetch_watched_with(&octo, &tab, &orgs).await {
+    let prs = include_prs.unwrap_or(true);
+    let issues = include_issues.unwrap_or(true);
+    match fetch_watched_with(&octo, &tab, &orgs, prs, issues).await {
         Ok(items) => Ok(items),
         Err(err) => {
             if err.is_unauthorized {
@@ -1282,7 +1341,7 @@ mod tests {
 
     #[test]
     fn queries_for_tab_all_includes_involves_and_user_self() {
-        let qs = queries_for_tab("all", &[]);
+        let qs = queries_for_tab("all", &[], true, true);
         assert_eq!(qs.len(), 2);
         assert!(qs[0].contains("involves:@me"));
         assert!(qs[1].contains("user:@me"));
@@ -1290,7 +1349,12 @@ mod tests {
 
     #[test]
     fn queries_for_tab_all_expands_watched_orgs() {
-        let qs = queries_for_tab("all", &["Lecto-inc".to_string(), "other".to_string()]);
+        let qs = queries_for_tab(
+            "all",
+            &["Lecto-inc".to_string(), "other".to_string()],
+            true,
+            true,
+        );
         assert_eq!(qs.len(), 4);
         assert!(qs[2].contains("user:Lecto-inc"));
         assert!(qs[3].contains("user:other"));
@@ -1298,14 +1362,14 @@ mod tests {
 
     #[test]
     fn queries_for_tab_mine_ignores_watched_orgs() {
-        let qs = queries_for_tab("authored", &["Lecto-inc".to_string()]);
+        let qs = queries_for_tab("authored", &["Lecto-inc".to_string()], true, true);
         assert_eq!(qs.len(), 1);
         assert!(qs[0].contains("author:@me"));
     }
 
     #[test]
     fn queries_for_tab_review_includes_requested_and_reviewed_by() {
-        let qs = queries_for_tab("review", &[]);
+        let qs = queries_for_tab("review", &[], true, true);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().any(|q| q.contains("review-requested:@me")));
         assert!(qs.iter().any(|q| q.contains("reviewed-by:@me")));
@@ -1313,14 +1377,14 @@ mod tests {
 
     #[test]
     fn queries_for_tab_review_ignores_watched_orgs() {
-        let qs = queries_for_tab("review", &["Lecto-inc".to_string()]);
+        let qs = queries_for_tab("review", &["Lecto-inc".to_string()], true, true);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().all(|q| !q.contains("user:")));
     }
 
     #[test]
     fn queries_for_tab_mentions_includes_mentions_and_commenter() {
-        let qs = queries_for_tab("mentions", &[]);
+        let qs = queries_for_tab("mentions", &[], true, true);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().any(|q| q.contains("mentions:@me")));
         assert!(qs.iter().any(|q| q.contains("commenter:@me")));
@@ -1328,23 +1392,98 @@ mod tests {
 
     #[test]
     fn queries_for_tab_mentions_ignores_watched_orgs() {
-        let qs = queries_for_tab("mentions", &["Lecto-inc".to_string()]);
+        let qs = queries_for_tab("mentions", &["Lecto-inc".to_string()], true, true);
         assert_eq!(qs.len(), 2);
         assert!(qs.iter().all(|q| !q.contains("user:")));
     }
 
     #[test]
     fn queries_for_tab_strips_unsafe_chars_from_org() {
-        let qs = queries_for_tab("all", &["bad org!".to_string()]);
+        let qs = queries_for_tab("all", &["bad org!".to_string()], true, true);
         // spaces and "!" get filtered out; "badorg" survives
         assert!(qs.last().unwrap().contains("user:badorg"));
     }
 
     #[test]
     fn queries_for_tab_drops_fully_invalid_org() {
-        let qs = queries_for_tab("all", &["!@#$".to_string()]);
+        let qs = queries_for_tab("all", &["!@#$".to_string()], true, true);
         // only the two base queries remain
         assert_eq!(qs.len(), 2);
+    }
+
+    #[test]
+    fn queries_for_tab_all_with_prs_only_prefixes_is_pr() {
+        // Issues off → every query in the tab gets an `is:pr` narrowing prefix
+        // so GitHub returns PRs alone. This preserves the pre-toggle default
+        // for users who don't want issue noise.
+        let qs = queries_for_tab("all", &["Lecto-inc".to_string()], true, false);
+        assert_eq!(qs.len(), 3);
+        assert!(qs.iter().all(|q| q.contains("is:pr ")));
+        assert!(qs.iter().all(|q| !q.contains("is:issue ")));
+    }
+
+    #[test]
+    fn queries_for_tab_all_with_issues_only_prefixes_is_issue() {
+        // PRs off → every query gets `is:issue`. Watched_orgs gains an
+        // `is:issue user:{org}` query, which is the fix for the original
+        // motivating bug: Sentry-bot-authored issues from a watched org
+        // showing up.
+        let qs = queries_for_tab("all", &["Lecto-inc".to_string()], false, true);
+        assert_eq!(qs.len(), 3);
+        assert!(qs.iter().all(|q| q.contains("is:issue ")));
+        assert!(qs.iter().all(|q| !q.contains("is:pr ")));
+        assert!(qs
+            .iter()
+            .any(|q| q.contains("is:issue user:Lecto-inc archived:false")));
+    }
+
+    #[test]
+    fn queries_for_tab_all_with_both_kinds_omits_kind_filter() {
+        // With both kinds on we want a single unprefixed query per template —
+        // GitHub returns both PullRequest and Issue nodes when no `is:`
+        // narrowing is supplied, so running both `is:pr` and `is:issue` would
+        // just double the request count for no extra coverage.
+        let qs = queries_for_tab("all", &["Lecto-inc".to_string()], true, true);
+        assert_eq!(qs.len(), 3);
+        assert!(qs.iter().all(|q| !q.contains("is:pr ")));
+        assert!(qs.iter().all(|q| !q.contains("is:issue ")));
+        assert!(qs
+            .iter()
+            .any(|q| q.contains("user:Lecto-inc archived:false")));
+    }
+
+    #[test]
+    fn queries_for_tab_review_is_empty_when_prs_off() {
+        // Reviews don't exist on issues — when the user has hidden PRs the
+        // tab should be empty rather than firing a query that GitHub would
+        // silently return zero rows for.
+        let qs = queries_for_tab("review", &[], false, true);
+        assert!(qs.is_empty());
+    }
+
+    #[test]
+    fn queries_for_tab_authored_with_issues_only_uses_is_issue() {
+        let qs = queries_for_tab("authored", &[], false, true);
+        assert_eq!(qs.len(), 1);
+        assert!(qs[0].contains("is:issue author:@me"));
+    }
+
+    #[test]
+    fn queries_for_tab_mentions_with_issues_only_filters_both_queries() {
+        let qs = queries_for_tab("mentions", &[], false, true);
+        assert_eq!(qs.len(), 2);
+        assert!(qs.iter().all(|q| q.contains("is:issue ")));
+    }
+
+    #[test]
+    fn queries_for_tab_both_off_returns_empty() {
+        // Defense in depth: the frontend disables the checkbox that would
+        // produce this state, but a stale config or a malformed import
+        // mustn't blow up the query builder.
+        assert!(queries_for_tab("all", &["Lecto-inc".to_string()], false, false).is_empty());
+        assert!(queries_for_tab("authored", &[], false, false).is_empty());
+        assert!(queries_for_tab("mentions", &[], false, false).is_empty());
+        assert!(queries_for_tab("review", &[], false, false).is_empty());
     }
 
     #[test]

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import type { Update } from "@tauri-apps/plugin-updater";
-  import type { Theme } from "$lib/storage";
+  import type { RepoSetting, Theme } from "$lib/storage";
   import { isTextCaretTarget } from "$lib/shortcuts";
 
   type UpdateStatus =
@@ -30,14 +30,14 @@
     shortcutError: string | null;
     updateStatus: UpdateStatus;
     watchedOrgs: SvelteSet<string>;
-    excludedRepos: SvelteSet<string>;
+    repoSettings: Map<string, RepoSetting>;
     orgSuggestions: string[];
     repoSuggestions: string[];
     error: string | null;
     settingsIoNotice: string | null;
     settingsIoError: string | null;
     newWatchedOrg: string;
-    newExcludedRepo: string;
+    newRepoOverride: string;
     onBack: () => void;
     onIntervalChange: (value: number) => void;
     onNotifyChange: (enabled: boolean) => void;
@@ -52,8 +52,9 @@
     onStartCaptureShortcut: () => void;
     onAddWatchedOrg: () => void;
     onRemoveWatchedOrg: (org: string) => void;
-    onAddExcludedRepo: () => void;
-    onRemoveExcludedRepo: (repo: string) => void;
+    onAddRepoOverride: () => void;
+    onRemoveRepoOverride: (repo: string) => void;
+    onUpdateRepoOverride: (repo: string, next: RepoSetting) => void;
     onExportSettings: () => void;
     onImportSettings: () => void;
   };
@@ -74,14 +75,14 @@
     shortcutError,
     updateStatus,
     watchedOrgs,
-    excludedRepos,
+    repoSettings,
     orgSuggestions,
     repoSuggestions,
     error,
     settingsIoNotice,
     settingsIoError,
     newWatchedOrg = $bindable(),
-    newExcludedRepo = $bindable(),
+    newRepoOverride = $bindable(),
     onBack,
     onIntervalChange,
     onNotifyChange,
@@ -96,11 +97,18 @@
     onStartCaptureShortcut,
     onAddWatchedOrg,
     onRemoveWatchedOrg,
-    onAddExcludedRepo,
-    onRemoveExcludedRepo,
+    onAddRepoOverride,
+    onRemoveRepoOverride,
+    onUpdateRepoOverride,
     onExportSettings,
     onImportSettings,
   }: Props = $props();
+
+  // Render override rows in deterministic order. Sort by repo name so a
+  // settings tweak doesn't reshuffle the list under the user's cursor.
+  const sortedRepoOverrides = $derived(
+    [...repoSettings.entries()].sort(([a], [b]) => a.localeCompare(b)),
+  );
 
   let sectionEl: HTMLElement | undefined;
   let backEl: HTMLButtonElement | undefined;
@@ -328,19 +336,52 @@
     </div>
 
     <div class="setting-section">
-      <span class="setting-label">Excluded repositories</span>
-      {#if excludedRepos.size === 0}
-        <p class="setting-hint">None. Items from all repos are shown.</p>
+      <span class="setting-label">Repository overrides</span>
+      {#if sortedRepoOverrides.length === 0}
+        <p class="setting-hint">
+          None. All repos respect the global Include toggles above. Add a
+          repo to flip PRs or Issues on/off just for that repo. Unchecking
+          both hides the repo entirely (replaces the old Excluded list).
+        </p>
       {:else}
-        <ul class="excluded-list">
-          {#each [...excludedRepos].sort() as repo (repo)}
-            <li>
-              <span class="excluded-repo">{repo}</span>
+        <p class="setting-hint">
+          Per-repo PR / Issue toggles. With the matching global toggle on
+          this just narrows; with the global toggle off, ticking the box
+          here brings that kind back in for this repo via an extra search.
+        </p>
+        <ul class="repo-overrides">
+          {#each sortedRepoOverrides as [repo, s] (repo)}
+            <li class="repo-override-row">
+              <span class="repo-override-name" title={repo}>{repo}</span>
+              <label class="repo-override-toggle" title="Show PRs">
+                <input
+                  type="checkbox"
+                  checked={s.prs}
+                  onchange={(e) =>
+                    onUpdateRepoOverride(repo, {
+                      prs: e.currentTarget.checked,
+                      issues: s.issues,
+                    })}
+                />
+                <span>PRs</span>
+              </label>
+              <label class="repo-override-toggle" title="Show Issues">
+                <input
+                  type="checkbox"
+                  checked={s.issues}
+                  onchange={(e) =>
+                    onUpdateRepoOverride(repo, {
+                      prs: s.prs,
+                      issues: e.currentTarget.checked,
+                    })}
+                />
+                <span>Issues</span>
+              </label>
               <button
                 class="row-action"
-                onclick={() => onRemoveExcludedRepo(repo)}
-                aria-label="Remove"
-                title="Remove"
+                onclick={() => onRemoveRepoOverride(repo)}
+                aria-label="Remove override"
+                title="Remove override (back to global defaults)"
               >
                 ×
               </button>
@@ -353,15 +394,15 @@
           type="text"
           list="repo-suggestions"
           placeholder="owner/repo"
-          bind:value={newExcludedRepo}
-          onkeydown={(e) => e.key === "Enter" && onAddExcludedRepo()}
+          bind:value={newRepoOverride}
+          onkeydown={(e) => e.key === "Enter" && onAddRepoOverride()}
         />
         <datalist id="repo-suggestions">
           {#each repoSuggestions as repo (repo)}
             <option value={repo}></option>
           {/each}
         </datalist>
-        <button class="secondary" onclick={onAddExcludedRepo}>Add</button>
+        <button class="secondary" onclick={onAddRepoOverride}>Add</button>
       </div>
     </div>
 
@@ -621,6 +662,52 @@
     background: var(--surface-1);
     color: inherit;
     min-width: 0;
+  }
+
+  .repo-overrides {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .repo-override-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    font-size: 12px;
+    border-radius: 5px;
+    background: var(--surface-1);
+  }
+
+  .repo-override-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .repo-override-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+    color: var(--fg-muted);
+  }
+
+  .repo-override-toggle input {
+    cursor: pointer;
+  }
+
+  .repo-override-row .row-action {
+    opacity: 0.6;
+  }
+
+  .repo-override-row:hover .row-action {
+    opacity: 1;
   }
 
   .shortcut-list {

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -19,6 +19,8 @@
     refreshOptions: { value: number; label: string }[];
     notifyEnabled: boolean;
     showLatestComment: boolean;
+    includePRs: boolean;
+    includeIssues: boolean;
     theme: Theme;
     themeOptions: { value: Theme; label: string }[];
     autostartEnabled: boolean | null;
@@ -40,6 +42,8 @@
     onIntervalChange: (value: number) => void;
     onNotifyChange: (enabled: boolean) => void;
     onShowLatestCommentChange: (enabled: boolean) => void;
+    onIncludePRsChange: (enabled: boolean) => void;
+    onIncludeIssuesChange: (enabled: boolean) => void;
     onThemeChange: (value: Theme) => void;
     onToggleAutostart: (enabled: boolean) => void;
     onSendTestNotification: () => void;
@@ -59,6 +63,8 @@
     refreshOptions,
     notifyEnabled,
     showLatestComment,
+    includePRs,
+    includeIssues,
     theme,
     themeOptions,
     autostartEnabled,
@@ -80,6 +86,8 @@
     onIntervalChange,
     onNotifyChange,
     onShowLatestCommentChange,
+    onIncludePRsChange,
+    onIncludeIssuesChange,
     onThemeChange,
     onToggleAutostart,
     onSendTestNotification,
@@ -168,6 +176,30 @@
         type="checkbox"
         checked={showLatestComment}
         onchange={(e) => onShowLatestCommentChange(e.currentTarget.checked)}
+      />
+    </label>
+    <label
+      class="setting-row"
+      title="Turn off to hide PRs across every tab and watched org."
+    >
+      <span class="setting-label">Include PRs</span>
+      <input
+        type="checkbox"
+        checked={includePRs}
+        disabled={includePRs && !includeIssues}
+        onchange={(e) => onIncludePRsChange(e.currentTarget.checked)}
+      />
+    </label>
+    <label
+      class="setting-row"
+      title="Turn off to hide Issues across every tab and watched org."
+    >
+      <span class="setting-label">Include Issues</span>
+      <input
+        type="checkbox"
+        checked={includeIssues}
+        disabled={includeIssues && !includePRs}
+        onchange={(e) => onIncludeIssuesChange(e.currentTarget.checked)}
       />
     </label>
     <label class="setting-row">
@@ -259,7 +291,7 @@
         <p class="setting-hint">
           Only your personal repos and items you're involved with show up in
           All. Add an org login (e.g. <code>Lecto-inc</code>) to pull in all
-          open PRs from that org — catches dependabot PRs in org repos.
+          open items from that org — respects the PR / Issue toggles above.
         </p>
       {:else}
         <ul class="excluded-list">

--- a/src/lib/list.test.ts
+++ b/src/lib/list.test.ts
@@ -63,33 +63,51 @@ describe("itemKey", () => {
 
 describe("filterVisible", () => {
   const items = [
-    makeItem({ id: 1, repo: "a/a", number: 1 }),
-    makeItem({ id: 2, repo: "b/b", number: 2 }),
-    makeItem({ id: 3, repo: "c/c", number: 3 }),
+    makeItem({ id: 1, repo: "a/a", number: 1, kind: "pr" }),
+    makeItem({ id: 2, repo: "b/b", number: 2, kind: "pr" }),
+    makeItem({ id: 3, repo: "c/c", number: 3, kind: "pr" }),
   ];
 
   it("hides individually hidden items on non-hidden tabs", () => {
     const out = filterVisible(items, {
       tab: "all",
-      excludedRepos: new Set(),
+      repoSettings: new Map(),
       hiddenItems: new Set([2]),
     });
     expect(out.map((i) => i.id)).toEqual([1, 3]);
   });
 
-  it("hides items from excluded repos on non-hidden tabs", () => {
+  it("hides items from fully-overridden repos (prs:false, issues:false)", () => {
+    // The migration of the legacy excludedRepos lands as {prs:false,issues:false},
+    // which must still suppress everything from that repo regardless of kind.
     const out = filterVisible(items, {
       tab: "all",
-      excludedRepos: new Set(["c/c"]),
+      repoSettings: new Map([["c/c", { prs: false, issues: false }]]),
       hiddenItems: new Set(),
     });
     expect(out.map((i) => i.id)).toEqual([1, 2]);
   });
 
-  it("hidden tab shows only hidden items regardless of excluded repos", () => {
+  it("suppresses only the matching kind when override is partial", () => {
+    // c/c here has both a PR and an Issue with the same repo override
+    // (prs:false, issues:true) — the PR drops, the issue stays.
+    const mixed = [
+      makeItem({ id: 1, repo: "a/a", number: 1, kind: "pr" }),
+      makeItem({ id: 2, repo: "c/c", number: 2, kind: "pr" }),
+      makeItem({ id: 3, repo: "c/c", number: 3, kind: "issue" }),
+    ];
+    const out = filterVisible(mixed, {
+      tab: "all",
+      repoSettings: new Map([["c/c", { prs: false, issues: true }]]),
+      hiddenItems: new Set(),
+    });
+    expect(out.map((i) => i.id)).toEqual([1, 3]);
+  });
+
+  it("hidden tab shows only hidden items regardless of repo overrides", () => {
     const out = filterVisible(items, {
       tab: "hidden",
-      excludedRepos: new Set(["c/c"]),
+      repoSettings: new Map([["c/c", { prs: false, issues: false }]]),
       hiddenItems: new Set([3]),
     });
     expect(out.map((i) => i.id)).toEqual([3]);

--- a/src/lib/list.ts
+++ b/src/lib/list.ts
@@ -1,3 +1,4 @@
+import type { RepoSetting } from "./storage";
 import type { RepoGroup, Tab, WatchedItem } from "./types";
 
 export function relativeTime(iso: string, now: number = Date.now()): string {
@@ -39,11 +40,25 @@ export function flattenCommentBody(body: string): string {
   return kept.join(" ").split(/\s+/).filter(Boolean).join(" ");
 }
 
+/// True when this (repo, kind) is suppressed by a per-repo override. Items
+/// without an entry pass through unchanged — the global Include toggles
+/// decide whether they would even reach us.
+function suppressedByRepo(
+  item: WatchedItem,
+  repoSettings: ReadonlyMap<string, RepoSetting>,
+): boolean {
+  const s = repoSettings.get(item.repo);
+  if (!s) return false;
+  if (item.kind === "pr" && !s.prs) return true;
+  if (item.kind === "issue" && !s.issues) return true;
+  return false;
+}
+
 export function filterVisible(
   items: WatchedItem[],
   opts: {
     tab: Tab;
-    excludedRepos: ReadonlySet<string>;
+    repoSettings: ReadonlyMap<string, RepoSetting>;
     hiddenItems: ReadonlySet<number>;
   },
 ): WatchedItem[] {
@@ -51,7 +66,8 @@ export function filterVisible(
     return items.filter((i) => opts.hiddenItems.has(i.id));
   }
   return items.filter(
-    (i) => !opts.hiddenItems.has(i.id) && !opts.excludedRepos.has(i.repo),
+    (i) =>
+      !opts.hiddenItems.has(i.id) && !suppressedByRepo(i, opts.repoSettings),
   );
 }
 
@@ -164,11 +180,11 @@ export function groupByRepo(
 
 export function repoSuggestionsFrom(
   items: WatchedItem[],
-  excludedRepos: ReadonlySet<string>,
+  overriddenRepos: ReadonlySet<string>,
 ): string[] {
   const seen = new Set<string>();
   for (const item of items) {
-    if (!excludedRepos.has(item.repo)) seen.add(item.repo);
+    if (!overriddenRepos.has(item.repo)) seen.add(item.repo);
   }
   return [...seen].sort();
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -3,7 +3,11 @@ import type { Tab, ViewMode } from "$lib/types";
 export const TAB_KEY = "eir.tab";
 export const INTERVAL_KEY = "eir.refreshMs";
 export const NOTIFY_KEY = "eir.notifyEnabled";
+/// Legacy key — superseded by `eir.repoSettings`. Kept readable for one
+/// release so a user who downgrades doesn't lose their excluded list, but
+/// new code writes only to `eir.repoSettings`.
 export const EXCLUDED_REPOS_KEY = "eir.excludedRepos";
+export const REPO_SETTINGS_KEY = "eir.repoSettings";
 export const HIDDEN_ITEMS_KEY = "eir.hiddenItems";
 export const PINNED_ITEMS_KEY = "eir.pinnedItems";
 export const WATCHED_ORGS_KEY = "eir.watchedOrgs";
@@ -63,17 +67,67 @@ export function persistTab(value: Tab): void {
   localStorage.setItem(TAB_KEY, value);
 }
 
-export function loadExcludedRepos(): string[] {
+export type RepoSetting = { prs: boolean; issues: boolean };
+
+export function isRepoSetting(value: unknown): value is RepoSetting {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as RepoSetting).prs === "boolean" &&
+    typeof (value as RepoSetting).issues === "boolean"
+  );
+}
+
+export function isValidRepoName(value: unknown): value is string {
+  return typeof value === "string" && value.includes("/");
+}
+
+/// Coerce arbitrary input into a clean repoSettings map. Accepts either
+/// the new shape (Record<repo, RepoSetting>) or the legacy excludedRepos
+/// shape (string[] of fully-hidden repos), so a load from localStorage
+/// and an import from a saved JSON file can share the same migration.
+export function normalizeRepoSettingsInput(
+  newShape: unknown,
+  legacyExcluded: unknown,
+): Record<string, RepoSetting> {
+  const out: Record<string, RepoSetting> = {};
+  if (newShape && typeof newShape === "object" && !Array.isArray(newShape)) {
+    for (const [repo, val] of Object.entries(
+      newShape as Record<string, unknown>,
+    )) {
+      if (isValidRepoName(repo) && isRepoSetting(val) && !(val.prs && val.issues)) {
+        out[repo] = { prs: val.prs, issues: val.issues };
+      }
+    }
+    return out;
+  }
+  if (Array.isArray(legacyExcluded)) {
+    for (const repo of legacyExcluded) {
+      if (isValidRepoName(repo)) {
+        out[repo] = { prs: false, issues: false };
+      }
+    }
+  }
+  return out;
+}
+
+export function loadRepoSettings(): Record<string, RepoSetting> {
   try {
-    const raw = localStorage.getItem(EXCLUDED_REPOS_KEY);
-    return raw ? JSON.parse(raw) : [];
+    const raw = localStorage.getItem(REPO_SETTINGS_KEY);
+    const legacy = localStorage.getItem(EXCLUDED_REPOS_KEY);
+    return normalizeRepoSettingsInput(
+      raw ? JSON.parse(raw) : undefined,
+      legacy ? JSON.parse(legacy) : undefined,
+    );
   } catch {
-    return [];
+    return {};
   }
 }
 
-export function persistExcludedRepos(values: Iterable<string>): void {
-  localStorage.setItem(EXCLUDED_REPOS_KEY, JSON.stringify([...values]));
+export function persistRepoSettings(
+  settings: Record<string, RepoSetting>,
+): void {
+  localStorage.setItem(REPO_SETTINGS_KEY, JSON.stringify(settings));
 }
 
 export function loadHiddenItems(): number[] {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,6 +11,8 @@ export const THEME_KEY = "eir.theme";
 export const UNREAD_ONLY_KEY = "eir.unreadOnly";
 export const SHOW_LATEST_COMMENT_KEY = "eir.showLatestComment";
 export const VIEW_MODE_KEY = "eir.viewMode";
+export const INCLUDE_PRS_KEY = "eir.includePRs";
+export const INCLUDE_ISSUES_KEY = "eir.includeIssues";
 
 export const DEFAULT_REFRESH_MS = 60_000;
 
@@ -136,4 +138,20 @@ export function loadViewMode(): ViewMode {
 
 export function persistViewMode(value: ViewMode): void {
   localStorage.setItem(VIEW_MODE_KEY, value);
+}
+
+export function loadIncludePRs(): boolean {
+  return localStorage.getItem(INCLUDE_PRS_KEY) !== "0";
+}
+
+export function persistIncludePRs(enabled: boolean): void {
+  localStorage.setItem(INCLUDE_PRS_KEY, enabled ? "1" : "0");
+}
+
+export function loadIncludeIssues(): boolean {
+  return localStorage.getItem(INCLUDE_ISSUES_KEY) !== "0";
+}
+
+export function persistIncludeIssues(enabled: boolean): void {
+  localStorage.setItem(INCLUDE_ISSUES_KEY, enabled ? "1" : "0");
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,7 +16,7 @@
     isEnabled as isAutostartEnabled,
   } from "@tauri-apps/plugin-autostart";
   import { onDestroy, onMount } from "svelte";
-  import { SvelteSet } from "svelte/reactivity";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import {
     filterBySearch,
     filterVisible,
@@ -26,32 +26,35 @@
     repoSuggestionsFrom,
   } from "$lib/list";
   import {
-    loadExcludedRepos,
+    isValidRepoName,
     loadHiddenItems,
     loadIncludeIssues,
     loadIncludePRs,
     loadInterval,
     loadNotify,
     loadPinnedItems,
+    loadRepoSettings,
     loadShowLatestComment,
     loadTab,
     loadTheme,
     loadUnreadOnly,
     loadViewMode,
     loadWatchedOrgs,
-    persistExcludedRepos,
+    normalizeRepoSettingsInput,
     persistHiddenItems,
     persistIncludeIssues,
     persistIncludePRs,
     persistInterval,
     persistNotify,
     persistPinnedItems,
+    persistRepoSettings,
     persistShowLatestComment,
     persistTab,
     persistTheme,
     persistUnreadOnly,
     persistViewMode,
     persistWatchedOrgs,
+    type RepoSetting,
     type Theme,
   } from "$lib/storage";
   import type { NotificationItem, Tab, ViewMode, WatchedItem } from "$lib/types";
@@ -143,12 +146,18 @@
   let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   let appVersion = $state<string>("");
   let autostartEnabled = $state<boolean | null>(null);
-  const excludedRepos = new SvelteSet<string>(loadExcludedRepos());
+  const repoSettings = new SvelteMap<string, RepoSetting>(
+    Object.entries(loadRepoSettings()),
+  );
   const hiddenItems = new SvelteSet<number>(loadHiddenItems());
   const pinnedItems = new SvelteSet<number>(loadPinnedItems());
   const watchedOrgs = new SvelteSet<string>(loadWatchedOrgs());
-  let newExcludedRepo = $state("");
+  let newRepoOverride = $state("");
   let newWatchedOrg = $state("");
+
+  function snapshotRepoSettings(): Record<string, RepoSetting> {
+    return Object.fromEntries(repoSettings.entries());
+  }
   let settingsIoError = $state<string | null>(null);
   let settingsIoNotice = $state<string | null>(null);
 
@@ -220,7 +229,7 @@
       intervalMs?: number;
       notifyEnabled?: boolean;
       watchedOrgs?: string[];
-      excludedRepos?: string[];
+      repoSettings?: Record<string, RepoSetting>;
       hiddenItems?: number[];
       includePRs?: boolean;
       includeIssues?: boolean;
@@ -232,7 +241,7 @@
         intervalMs: patch.intervalMs,
         notifyEnabled: patch.notifyEnabled,
         watchedOrgs: patch.watchedOrgs,
-        excludedRepos: patch.excludedRepos,
+        repoSettings: patch.repoSettings,
         hiddenItems: patch.hiddenItems,
         includePrs: patch.includePRs,
         includeIssues: patch.includeIssues,
@@ -246,7 +255,7 @@
       intervalMs: refreshMs,
       notifyEnabled,
       watchedOrgs: [...watchedOrgs],
-      excludedRepos: [...excludedRepos],
+      repoSettings: snapshotRepoSettings(),
       hiddenItems: [...hiddenItems],
       includePRs,
       includeIssues,
@@ -754,19 +763,35 @@
     persistPinnedItems(pinnedItems);
   }
 
-  function addExcludedRepo() {
-    const name = newExcludedRepo.trim();
-    if (!name || !name.includes("/")) return;
-    excludedRepos.add(name);
-    persistExcludedRepos(excludedRepos);
-    newExcludedRepo = "";
-    void pushBackgroundConfig({ excludedRepos: [...excludedRepos] });
+  function commitRepoSettings() {
+    const snap = snapshotRepoSettings();
+    persistRepoSettings(snap);
+    void pushBackgroundConfig({ repoSettings: snap });
   }
 
-  function removeExcludedRepo(repo: string) {
-    excludedRepos.delete(repo);
-    persistExcludedRepos(excludedRepos);
-    void pushBackgroundConfig({ excludedRepos: [...excludedRepos] });
+  function addRepoOverride() {
+    const name = newRepoOverride.trim();
+    if (!isValidRepoName(name) || repoSettings.has(name)) {
+      newRepoOverride = "";
+      return;
+    }
+    repoSettings.set(name, { prs: true, issues: false });
+    commitRepoSettings();
+    newRepoOverride = "";
+  }
+
+  function removeRepoOverride(repo: string) {
+    if (!repoSettings.delete(repo)) return;
+    commitRepoSettings();
+  }
+
+  function updateRepoOverride(repo: string, next: RepoSetting) {
+    if (next.prs && next.issues) {
+      removeRepoOverride(repo);
+      return;
+    }
+    repoSettings.set(repo, next);
+    commitRepoSettings();
   }
 
   async function addWatchedOrg() {
@@ -829,7 +854,10 @@
     includePRs?: boolean;
     includeIssues?: boolean;
     theme?: Theme;
+    /// Pre-per-repo builds wrote this string array; kept on the import side
+    /// so a re-import doesn't silently lose someone's exclusion list.
     excludedRepos?: string[];
+    repoSettings?: Record<string, RepoSetting>;
     watchedOrgs?: string[];
     hiddenItems?: number[];
     pinnedItems?: number[];
@@ -845,7 +873,9 @@
       includePRs,
       includeIssues,
       theme,
-      excludedRepos: [...excludedRepos].sort(),
+      repoSettings: Object.fromEntries(
+        [...repoSettings.entries()].sort(([a], [b]) => a.localeCompare(b)),
+      ),
       watchedOrgs: [...watchedOrgs].sort(),
       hiddenItems: [...hiddenItems].sort((a, b) => a - b),
       pinnedItems: [...pinnedItems].sort((a, b) => a - b),
@@ -965,14 +995,17 @@
       applied.push("theme");
     }
 
-    if (Array.isArray(data.excludedRepos)) {
-      const next = data.excludedRepos.filter(
-        (r): r is string => typeof r === "string" && r.includes("/"),
+    if (data.repoSettings !== undefined || data.excludedRepos !== undefined) {
+      const next = normalizeRepoSettingsInput(
+        data.repoSettings,
+        data.excludedRepos,
       );
-      excludedRepos.clear();
-      for (const r of next) excludedRepos.add(r);
-      persistExcludedRepos(excludedRepos);
-      applied.push("excluded repos");
+      repoSettings.clear();
+      for (const [repo, s] of Object.entries(next)) {
+        repoSettings.set(repo, s);
+      }
+      persistRepoSettings(snapshotRepoSettings());
+      applied.push("repo overrides");
     }
 
     if (Array.isArray(data.watchedOrgs)) {
@@ -1027,7 +1060,7 @@
   }
 
   const repoSuggestions = $derived(
-    repoSuggestionsFrom(items, excludedRepos),
+    repoSuggestionsFrom(items, new Set(repoSettings.keys())),
   );
 
   const orgSuggestions = $derived.by<string[]>(() => {
@@ -1045,7 +1078,7 @@
     const base = filterBySearch(
       filterVisible(items, {
         tab: activeTab,
-        excludedRepos,
+        repoSettings,
         hiddenItems,
       }),
       searchQuery,
@@ -1158,14 +1191,14 @@
       {shortcutError}
       {updateStatus}
       {watchedOrgs}
-      {excludedRepos}
+      {repoSettings}
       {orgSuggestions}
       {repoSuggestions}
       {error}
       {settingsIoNotice}
       {settingsIoError}
       bind:newWatchedOrg
-      bind:newExcludedRepo
+      bind:newRepoOverride
       onBack={() => (showingSettings = false)}
       {onIntervalChange}
       {onNotifyChange}
@@ -1180,8 +1213,9 @@
       onStartCaptureShortcut={startCaptureShortcut}
       onAddWatchedOrg={addWatchedOrg}
       onRemoveWatchedOrg={removeWatchedOrg}
-      onAddExcludedRepo={addExcludedRepo}
-      onRemoveExcludedRepo={removeExcludedRepo}
+      onAddRepoOverride={addRepoOverride}
+      onRemoveRepoOverride={removeRepoOverride}
+      onUpdateRepoOverride={updateRepoOverride}
       onExportSettings={exportSettings}
       onImportSettings={importSettings}
     />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -804,12 +804,19 @@
 
   async function switchTab(tab: Tab) {
     if (tab === activeTab) return;
+    const prevServerTab = serverTab(activeTab);
+    const nextServerTab = serverTab(tab);
     activeTab = tab;
     persistTab(tab);
-    // Clear locally so the old tab's items don't linger until the worker's
-    // emit arrives. The worker resets its diff anchors on tab change.
-    items = [];
-    await pushBackgroundConfig({ tab });
+    // Only clear + re-push when the worker's tab actually changes. `hidden`
+    // is a client-side filter that maps to `all` server-side, so e.g.
+    // `all → hidden` and `hidden → all` keep the same server tab — wiping
+    // `items` there would strand the UI on an empty list since the worker
+    // would see no tab diff and skip the re-emit.
+    if (prevServerTab !== nextServerTab) {
+      items = [];
+      await pushBackgroundConfig({ tab });
+    }
   }
 
   const SETTINGS_EXPORT_VERSION = 1;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,8 @@
   import {
     loadExcludedRepos,
     loadHiddenItems,
+    loadIncludeIssues,
+    loadIncludePRs,
     loadInterval,
     loadNotify,
     loadPinnedItems,
@@ -39,6 +41,8 @@
     loadWatchedOrgs,
     persistExcludedRepos,
     persistHiddenItems,
+    persistIncludeIssues,
+    persistIncludePRs,
     persistInterval,
     persistNotify,
     persistPinnedItems,
@@ -96,6 +100,8 @@
   let refreshMs = $state<number>(loadInterval());
   let notifyEnabled = $state<boolean>(loadNotify());
   let showLatestComment = $state<boolean>(loadShowLatestComment());
+  let includePRs = $state<boolean>(loadIncludePRs());
+  let includeIssues = $state<boolean>(loadIncludeIssues());
   let theme = $state<Theme>(loadTheme());
   let systemDark = $state<boolean>(
     window.matchMedia("(prefers-color-scheme: dark)").matches,
@@ -216,6 +222,8 @@
       watchedOrgs?: string[];
       excludedRepos?: string[];
       hiddenItems?: number[];
+      includePRs?: boolean;
+      includeIssues?: boolean;
     } = {},
   ) {
     await invoke("set_background_config", {
@@ -226,6 +234,8 @@
         watchedOrgs: patch.watchedOrgs,
         excludedRepos: patch.excludedRepos,
         hiddenItems: patch.hiddenItems,
+        includePrs: patch.includePRs,
+        includeIssues: patch.includeIssues,
       },
     }).catch((e) => console.warn("[eir] set_background_config failed:", e));
   }
@@ -238,6 +248,8 @@
       watchedOrgs: [...watchedOrgs],
       excludedRepos: [...excludedRepos],
       hiddenItems: [...hiddenItems],
+      includePRs,
+      includeIssues,
     });
   }
 
@@ -702,6 +714,25 @@
     persistShowLatestComment(enabled);
   }
 
+  async function onIncludePRsChange(enabled: boolean) {
+    // Guard against the disabled-checkbox case getting bypassed (keyboard /
+    // automation): turning both off would leave the worker with nothing to
+    // fetch and the list permanently empty.
+    if (!enabled && !includeIssues) return;
+    includePRs = enabled;
+    persistIncludePRs(enabled);
+    items = [];
+    await pushBackgroundConfig({ includePRs: enabled });
+  }
+
+  async function onIncludeIssuesChange(enabled: boolean) {
+    if (!enabled && !includePRs) return;
+    includeIssues = enabled;
+    persistIncludeIssues(enabled);
+    items = [];
+    await pushBackgroundConfig({ includeIssues: enabled });
+  }
+
   function hideItem(id: number) {
     hiddenItems.add(id);
     persistHiddenItems(hiddenItems);
@@ -788,6 +819,8 @@
     refreshMs?: number;
     notifyEnabled?: boolean;
     showLatestComment?: boolean;
+    includePRs?: boolean;
+    includeIssues?: boolean;
     theme?: Theme;
     excludedRepos?: string[];
     watchedOrgs?: string[];
@@ -802,6 +835,8 @@
       refreshMs,
       notifyEnabled,
       showLatestComment,
+      includePRs,
+      includeIssues,
       theme,
       excludedRepos: [...excludedRepos].sort(),
       watchedOrgs: [...watchedOrgs].sort(),
@@ -882,6 +917,36 @@
     if (typeof data.showLatestComment === "boolean") {
       onShowLatestCommentChange(data.showLatestComment);
       applied.push("latest comment preview");
+    }
+
+    // Apply include flags raw (skipping the both-off guard in the change
+    // handlers) so a valid export with both true / one true survives, and a
+    // (defensive) both-false case falls through to the next field rather than
+    // mutating state — pushFullConfig at the end re-syncs the worker either
+    // way.
+    const nextIncludePRs =
+      typeof data.includePRs === "boolean" ? data.includePRs : includePRs;
+    const nextIncludeIssues =
+      typeof data.includeIssues === "boolean"
+        ? data.includeIssues
+        : includeIssues;
+    if (nextIncludePRs || nextIncludeIssues) {
+      if (
+        typeof data.includePRs === "boolean" &&
+        data.includePRs !== includePRs
+      ) {
+        includePRs = data.includePRs;
+        persistIncludePRs(data.includePRs);
+        applied.push("include PRs");
+      }
+      if (
+        typeof data.includeIssues === "boolean" &&
+        data.includeIssues !== includeIssues
+      ) {
+        includeIssues = data.includeIssues;
+        persistIncludeIssues(data.includeIssues);
+        applied.push("include Issues");
+      }
     }
 
     if (
@@ -1075,6 +1140,8 @@
       refreshOptions={REFRESH_OPTIONS}
       {notifyEnabled}
       {showLatestComment}
+      {includePRs}
+      {includeIssues}
       {theme}
       themeOptions={THEME_OPTIONS}
       {autostartEnabled}
@@ -1096,6 +1163,8 @@
       {onIntervalChange}
       {onNotifyChange}
       {onShowLatestCommentChange}
+      {onIncludePRsChange}
+      {onIncludeIssuesChange}
       {onThemeChange}
       onToggleAutostart={toggleAutostart}
       onSendTestNotification={sendTestNotification}


### PR DESCRIPTION
## Summary

GitHub Search の watched_orgs クエリが `is:pr` で固定されていたため、watched org の Issue (Sentry/Dependabot 由来など) が `involves:@me` 以外では拾えていなかった問題への対応として、PR/Issue の取り込みを 2 段階で制御できるようにする:

- **グローバル Include トグル** (`Include PRs` / `Include Issues`): 全タブ・全クエリに `is:pr` / `is:issue` プレフィックスを動的適用。
- **リポジトリ単位の override** (`Repository overrides`): 既存の Excluded list を置き換え、各 repo を `{prs, issues}` で個別制御。グローバル OFF + repo ON のときは GraphQL alias batching で `is:<kind> repo:<owner/name>` を **同じ HTTP リクエスト内に追加** (= 並列実行されるので追加 RTT 0)。
- **Hidden タブのバグ修正**: Hidden ⇄ All のように "サーバー視点で同じタブ" を行き来する場合に items を空にしてしまっていた挙動を直し、× で hide した item が Hidden タブにちゃんと現れるように。

## What's in this PR

| Commit | 概要 |
|---|---|
| `feat: add global PR/Issue include toggles` | グローバル Include トグル + `queries_for_tab` の kind プレフィックス化 |
| `fix: keep items when switching between hidden and all tabs` | `serverTab` が変わらない切り替えで items を消さないように |
| `feat: per-repository PR/Issue overrides` | Repository overrides UI、widening クエリ層、Excluded → repoSettings マイグレーション、`MAX_WIDENING_REPOS = 25` cap |

## Override semantics

| Global | Repo override | 結果 |
|---|---|---|
| ON | ON | デフォルト (override は記録されない) |
| ON | OFF | 絞る (クライアント側フィルタ) |
| OFF | ON | 広げる (`is:<kind> repo:<owner/name>` を追加クエリ) |
| OFF | OFF | 旧 Excluded 相当 (完全非表示) |

## Migration

旧 `eir.excludedRepos` (string array) は起動時に `{prs:false, issues:false}` として `eir.repoSettings` に取り込まれる。JSON 設定の import 側も同じ helper (`normalizeRepoSettingsInput`) を経由するので、過去のエクスポートファイルから戻しても excluded list が失われない。

## Notes for reviewers

- **Widening は All タブのみ適用**: Mine / Review / Mentions は既に opinionated なレンズで、widening を引き継ぐと「ユーザーが頼んでいない」item が混入するため意図的に外している。
- **`MAX_WIDENING_REPOS = 25`**: GitHub GraphQL の complexity 上限を守る defensive cap。corrupted import / 大量 paste で 1 リクエストが拒否されるのを防止。超過分は黙ってドロップ (entries は repo 名でソートしてから cap を適用するので決定的)。
- **`apply_background_config` の `repo_settings` 分岐は narrowing-only の変更でも refetch する**: 厳密には不要だが、widening 判定を分けると state 比較が複雑化する。設定変更は人間操作のキャデンスなので過剰最適化と判断 (コメントに記載)。
- **既存 `excluded_repos` フィルタ箇所**: `update_tray_badge` 等で `excluded_repos.contains()` を `suppressed_by_repo()` に置換。HashMap 1 lookup なので複雑度は同じ。

## Test plan

- [x] `cargo test --lib` — 121 passed (新規 widening 6 テスト + cap テスト 1 + repo_settings 3 テスト含む)
- [x] `cargo clippy --all-targets -- -D warnings` — クリーン
- [x] `cargo fmt --check` — クリーン
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm test` — 46 passed
- [ ] 実機 (`pnpm tauri dev`) 確認:
  - [ ] Settings に Include PRs / Include Issues トグルが現れ、片方を OFF にすると相手は disabled になる
  - [ ] Repository overrides に repo を追加、PR/Issue を個別 ON/OFF
  - [ ] 両方 ON に戻すと行が自動消滅
  - [ ] Lecto-inc を watched org に追加 + Include Issues=ON で `Lecto-inc/primeape#4413` (Sentry bot 作の Issue) が表示される
  - [ ] グローバル Issue=OFF + 特定 repo の Issue=ON で、その repo の Issue だけが現れる
  - [ ] Issue を × で hide → Hidden タブで見えること、Hidden → All で list が空にならないこと
  - [ ] 旧 Excluded を持っている state でアップデート → Repository overrides に自動移行されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)