### PR TITLE
feat: periodic update check every hour

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -275,6 +275,9 @@
         {/if}
       </button>
     </div>
+    <p class="setting-hint update-hint">
+      Checked automatically once per hour while the app is running.
+    </p>
     <div class="setting-row">
       <span class="setting-label">Toggle popup shortcut</span>
       <button
@@ -563,6 +566,10 @@
     margin: 8px 0 0;
     font-size: 11px;
     color: var(--fg-muted);
+  }
+
+  .setting-hint.update-hint {
+    margin-top: -4px;
   }
 
   .shortcut-capture {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,6 +91,9 @@
     { value: 120_000, label: "2 minutes" },
     { value: 300_000, label: "5 minutes" },
   ];
+  // Re-checked once an hour; skipped while an update is already queued or
+  // installing — see startUpdateCheckTimer.
+  const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
   let phase = $state<Phase>("bootstrapping");
   let deviceCode = $state<DeviceCode | null>(null);
@@ -165,6 +168,7 @@
   let unlistenStateUpdated: UnlistenFn | null = null;
   let systemThemeMedia: MediaQueryList | null = null;
   let systemThemeListener: ((e: MediaQueryListEvent) => void) | null = null;
+  let updateCheckTimer: ReturnType<typeof setInterval> | null = null;
 
   $effect(() => {
     const resolved =
@@ -337,6 +341,30 @@
     }
   }
 
+  function startUpdateCheckTimer() {
+    stopUpdateCheckTimer();
+    updateCheckTimer = setInterval(() => {
+      // Skip once an update is already on deck — re-checking would just
+      // re-fire the same notification and clobber the user's in-progress
+      // install state.
+      if (
+        updateStatus.kind === "available" ||
+        updateStatus.kind === "downloading" ||
+        updateStatus.kind === "installed"
+      ) {
+        return;
+      }
+      void runUpdateCheck({ interactive: false });
+    }, UPDATE_CHECK_INTERVAL_MS);
+  }
+
+  function stopUpdateCheckTimer() {
+    if (updateCheckTimer != null) {
+      clearInterval(updateCheckTimer);
+      updateCheckTimer = null;
+    }
+  }
+
   async function installPendingUpdate() {
     if (updateStatus.kind !== "available") return;
     const update = updateStatus.update;
@@ -422,6 +450,7 @@
     }
 
     void runUpdateCheck({ interactive: false });
+    startUpdateCheckTimer();
 
     // Kick the permission dialog early so the first real notification isn't
     // also the first time the OS is asked — which silently denies in some
@@ -452,6 +481,7 @@
     }
     systemThemeMedia = null;
     systemThemeListener = null;
+    stopUpdateCheckTimer();
   });
 
   function handleVisibilityChange() {


### PR DESCRIPTION
## Summary
- Run the Tauri updater check once per hour (in addition to the existing on-startup check), so users notice new releases without reopening the popup or clicking *Check*.
- Skip the timer-driven check while an update is already \`available\` / \`downloading\` / \`installed\` to avoid re-firing notifications or clobbering an in-progress install.
- Add a short caption under the *Check for updates* row in Settings: "Checked automatically once per hour while the app is running."

## Why
Until now, the updater only ran once on app start. For a menubar app that's left running for days, that means a fresh release sits unnoticed until the next relaunch. Hourly is frequent enough to catch a release the same day without spamming the updater endpoint or the notification permission.

## Notes for reviewers
- Implementation lives entirely in [\`src/routes/+page.svelte\`](src/routes/+page.svelte) — a plain \`setInterval\` started after the initial check in \`onMount\`, cleared in \`onDestroy\`.
- The existing \`runUpdateCheck\` already guards against concurrent \`checking\` / \`downloading\` states; the timer wrapper additionally skips when \`available\` / \`installed\` so the user's queued install isn't disturbed.
- No new persisted state, no new IPC, no Rust changes.

## Test plan
- [ ] \`pnpm check\` passes (verified locally — 0 errors)
- [ ] Manually verify: open the app, wait ≥1h with no pending update, confirm a check fires (console: \`[eir] update check: already latest\`)
- [ ] With a draft release present, confirm the timer flips Settings into "v… available" and Install button without dropping focus or re-pinging the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)