### PR TITLE
fix: add scrollbar gutter padding in Settings

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -507,6 +507,7 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    padding-right: 8px;
   }
 
   .settings-header {


### PR DESCRIPTION
## Summary
- 設定画面のスクロールバーが表示されたとき、Repository overrides のチェックボックスや `×` ボタンがバーに隠れてしまっていた
- `.settings`（スクロールコンテナ）に `padding-right: 8px` を追加して、コンテンツとスクロールバーの間に余白を確保

## Test plan
- [ ] `pnpm tauri dev` を起動して設定画面を開く
- [ ] スクロールバーが出る程度に項目が多い状態で、Repository overrides 行の右端（Issues チェックボックス、`×` ボタン）がスクロールバーにかからず読める
- [ ] スクロールバーが出ない状態でもレイアウトが崩れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)