### PR TITLE
fix: relaunch via Launch Services on macOS after updater install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-**eir** is a macOS menubar-only app that watches GitHub PRs and Issues (a Trailer/Neat alternative). Stack: Tauri v2 (Rust) + SvelteKit (TypeScript, SPA mode) + pnpm. Bundle identifier `dev.yagince.eir`.
+**eir** is a menubar / system-tray app that watches GitHub PRs and Issues (a Trailer/Neat alternative). Stack: Tauri v2 (Rust) + SvelteKit (TypeScript, SPA mode) + pnpm. Bundle identifier `dev.yagince.eir`.
 
-The device-flow auth, list UI, grouping, filter tabs, auto-refresh, native notifications, tray badge, global shortcut, and a settings panel are all in place.
+Targets macOS (arm64 + x64), Windows x64, and Linux x64. CI and the release workflow build all four targets. macOS is the primary development and testing target — non-macOS code paths exist but receive less real-world coverage.
+
+Shipped features: OAuth device-flow auth, grouped list UI, filter tabs (all / mine / review / mentions / hidden), repo grouping with per-repo overrides, auto-refresh, native notifications, tray badge, configurable global shortcut, GitHub Notifications API integration, in-app updater, autostart, settings panel.
 
 ## Commands
 
@@ -32,7 +34,7 @@ pnpm check
 # Frontend tests (vitest)
 pnpm test
 
-# Production bundle (.app / .dmg)
+# Production bundle (.dmg on macOS, .msi/-setup.exe on Windows, .AppImage/.deb on Linux)
 pnpm tauri build
 
 # Regenerate app icons from a source PNG (does not touch tray icon)
@@ -43,31 +45,39 @@ Do not run `pnpm tauri dev` in the background — exit code 0 means the user qui
 
 ## Architecture
 
-The app is **menubar-only** — there is no dock icon, no traditional window. UX is a tray icon plus a popup, with a Ctrl+Shift+E global shortcut as an alternate entry point.
+The app is **menubar / system-tray only** — no dock or taskbar icon, no traditional window. UX is a tray icon plus a popup, with a Ctrl+Shift+E global shortcut (default; user-rebindable) as an alternate entry point.
 
 ### Rust side (`src-tauri/src/`)
 
 Module split:
-- `lib.rs` — `run()`: wires plugins (opener, notification, global-shortcut), installs rustls' `aws_lc_rs` provider, manages `AppState`, registers the toggle shortcut, and hosts the window-focus-loss handler that auto-hides the popup (suppressed when `AppState.pinned == true` during the device-flow code-copy window).
-- `auth.rs` — `AppState` (`Option<String>` token + `pinned` flag), device-flow commands (`start_device_flow`, `poll_device_flow`, `sign_out`, `set_window_pinned`), plus a simple `token_store` module that persists the token to `$HOME/.config/eir/token` with mode 0600. See the comment on the module for why we avoid the OS keychain (cdhash-based ACLs re-prompt on every rebuild/release). `AppState::with_stored_token()` is called from `run()` so a stored token is loaded at startup.
-- `github.rs` — `fetch_watched(tab)` runs a GitHub search with `octocrab`, mapped to a `WatchedItem` array. `query_for_tab` centralises the four tab queries (`all` / `authored` / `review` / `mentions`).
-- `tray.rs` — `setup()` builds the tray, `toggle_popup(app)` is the shared entry point for both tray clicks and the global shortcut (positions the window under the tray using `TrayIcon::rect()`, which is a `tauri::Position`/`tauri::Size` enum pair that must be pattern-matched — `Physical` on macOS in practice). `set_tray_badge(count)` updates the menubar title text for the unread count.
+- `lib.rs` — `run()`: wires plugins (opener, dialog, notification, updater, autostart, global-shortcut), installs rustls' `aws_lc_rs` provider, manages `AppState` + `BackgroundHandle`, registers the toggle shortcut, spawns the background fetch worker, and hosts the window-focus-loss handler that auto-hides the popup (suppressed when `AppState.pinned == true` during the device-flow code-copy window or settings dialogs). `ActivationPolicy::Accessory` is set on macOS only — other platforms rely on `skipTaskbar: true` for equivalent behavior.
+- `auth.rs` — `AppState` (`Option<String>` token + `pinned` flag), device-flow commands (`start_device_flow`, `poll_device_flow`, `sign_out`, `set_window_pinned`, `set_dialog_mode`), plus a `token_store` module that persists the token to `$HOME/.config/eir/token` (unix, mode 0600) or `%APPDATA%\eir\token` (Windows). See the comment on the module for why we avoid the OS keychain (cdhash-based ACLs re-prompt on every rebuild/release). `AppState::with_stored_token()` is called from `run()` so a stored token is loaded at startup.
+- `github.rs` — `fetch_watched(tab)` runs a GitHub search with `octocrab`, mapped to a `WatchedItem` array. `query_for_tab` centralises the four tab queries (`all` / `authored` / `review` / `mentions`). Also exposes `fetch_notifications`, `fetch_item_states`, and `mark_notification_read` for the Notifications-API enrichment path.
+- `background.rs` — Long-lived Rust worker that drives polling, diff detection, tray badge updates, and notification emission. Holds `BackgroundHandle` (config + cached state) and emits `state-updated` events to the frontend so the popup can re-render without owning its own timer (WKWebView throttles JS timers when hidden).
+- `diff.rs` — Pure functions for computing what changed between two `WatchedItem` snapshots — used by `background.rs` to decide which notifications to fire and how to label them ("New comment", "CI failed", "Updated", etc.).
+- `tray.rs` — `setup()` builds the tray, `toggle_popup(app)` is the shared entry point for both tray clicks and the global shortcut (positions the window under the tray using `TrayIcon::rect()`, which is a `tauri::Position`/`tauri::Size` enum pair that must be pattern-matched). `set_tray_badge(count, has_unread)` shows the unread count as an adjacent label + red-dot badge variant on macOS, and as a hover tooltip on Windows/Linux. Tray icon is monochrome template-mode on macOS, colored `32x32.png` elsewhere.
+- `shortcut.rs` — User-configurable global shortcut. Stored alongside other settings; loaded at startup and re-registered when changed.
+- `settings_io.rs` — `read_text_file` / `write_text_file` commands so the frontend can persist settings JSON without depending on `plugin-fs`.
+- `updater.rs` — `relaunch_app` command. On macOS, shells out to `/usr/bin/open -n <bundle>` so the new instance goes through Launch Services (the default `AppHandle::restart` spawns `current_exe` directly, which silently fails for `ActivationPolicy::Accessory` menubar apps after the updater swaps the .app bundle). On other platforms, falls back to `app.restart()`.
 
-Tauri config (`tauri.conf.json`) keeps the main window undecorated, `alwaysOnTop`, 380x520, hidden on launch. Capabilities (`capabilities/default.json`) grant `core:default`, `opener:default`, `notification:default`.
+Tauri config (`tauri.conf.json`) keeps the main window undecorated, `alwaysOnTop`, 440x680, hidden on launch, `skipTaskbar: true`. Capabilities (`capabilities/default.json`) grant `core:default`, `opener:default`, `dialog:default`, `notification:default`, `updater:default`, `autostart:default`.
 
 ### Frontend (`src/routes/+page.svelte`)
 
 Single Svelte 5 file, runes-based. Rendering is phase-driven:
 - `showingSettings` overrides all other phases.
-- `phase: "idle" | "pending" | "loaded"` — idle shows the sign-in CTA; pending shows the device code and opens GitHub; loaded shows the grouped list plus the tab bar and footer.
+- `phase: "bootstrapping" | "idle" | "pending" | "loaded"` — bootstrapping is the initial "restoring state from disk" state, idle shows the sign-in CTA, pending shows the device code and opens GitHub, loaded shows the grouped list plus the tab bar and footer.
+
+Auto-refresh and diff/notification logic live on the Rust side (`background.rs`). The frontend listens for `state-updated` events and re-renders from the payload — it does not own a JS timer (WKWebView throttles JS timers while the popup is hidden, so polling from Svelte would stall).
 
 Key state:
-- `items` / `prevIds` / `seen: SvelteSet<number>` — `prevIds` is an internal diff anchor for detecting newcomers to fire notifications; `seen` is a `SvelteSet` (reactive) persisted to `localStorage` under `eir.seen`. First load marks everything as seen to suppress notification noise; subsequent loads only notify for `newIds - prevIds`.
-- `activeTab` + `refreshMs` + `notifyEnabled` — all persisted (`eir.tab` / `eir.refreshMs` / `eir.notifyEnabled`). `refreshMs` changes trigger `restartRefreshIfRunning()`.
+- `items: WatchedItem[]` — replaced wholesale whenever a `state-updated` event arrives. The Rust worker keeps its own `prev_thread_updated_at` map to detect what changed; the frontend just renders.
+- `hiddenItems` / `pinnedItems` / `watchedOrgs` — `SvelteSet`s persisted to `localStorage` via helpers in `$lib/storage`.
+- `repoSettings: SvelteMap<string, RepoSetting>` — per-repo PR/Issue inclusion overrides. Changes are pushed to the Rust worker via `set_background_config` so the query set is updated immediately.
+- `activeTab` + `refreshMs` + `notifyEnabled` + global PR/Issue includes — all persisted; changes trigger a Rust-side config push.
 - `$derived.by` computes repo groups from `items`, sorted by most-recent update; each group carries its own unread count for the pill in the sticky header.
-- Auto-refresh is a plain `setInterval` managed by `startRefresh` / `stopRefresh` — started on first successful load, cleared on `onDestroy` or sign-out.
 
-Device-flow UX detail: on sign-in click the frontend calls `set_window_pinned(true)` so the popup doesn't hide when the browser steals focus. As soon as the user_code is on the clipboard (auto or manual) it flips to `set_window_pinned(false)`. When `poll_device_flow` resolves with a token, the Rust side calls `window.show()`+`set_focus()` to bring the popup back into view.
+Device-flow UX detail: on sign-in click the frontend calls `set_window_pinned(true)` so the popup doesn't hide when the browser steals focus. As soon as the user_code is on the clipboard (auto or manual) it flips to `set_window_pinned(false)`. When `poll_device_flow` resolves with a token, the Rust side calls `window.show()`+`set_focus()` to bring the popup back into view. The same `set_dialog_mode` / `set_window_pinned` mechanism is used to keep the popup visible while native dialogs (Settings save/load, update confirmation) are open.
 
 ### Icons
 
@@ -81,5 +91,6 @@ Icon generation uses a chroma-key workflow (nanobanana on solid `#00FF00` green 
 ## Known gotchas
 
 - **rustls CryptoProvider** — `reqwest`, `octocrab`, and other deps pull in both `aws-lc-rs` and `ring`. `run()` installs `aws_lc_rs::default_provider()` explicitly before anything else; removing that will panic on the first TLS handshake.
-- **macOS-specific behaviour** — `ActivationPolicy::Accessory`, `icon_as_template`, and the tray-based window positioning all target macOS. Cross-platform support is doable (keyring crate already covers Windows via `windows-native` and Linux via `sync-secret-service`) but tray/window placement will need platform branches.
-- **Phase 3 candidates still open** — GitHub Notifications API integration (more accurate "mentioned" semantics), per-PR review/CI status, user-configurable global shortcut. None are started.
+- **macOS updater relaunch** — `AppHandle::restart()` / `tauri-plugin-process`'s `relaunch()` spawn `current_exe()` directly. For an `Accessory` menubar app this bypasses Launch Services and silently fails right after the updater swaps the .app bundle (the old process exits, no new menubar icon). Use `updater::relaunch_app` instead, which goes through `/usr/bin/open -n` on macOS.
+- **Cross-platform parity** — Code branches exist for Windows and Linux (token path, tray icon variant, tray label vs. tooltip, popup sizing, updater relaunch), and CI builds all four targets. macOS is the primary test surface — non-mac paths are likely to have rough edges (e.g., Linux tray availability depends on the DE; GNOME needs the AppIndicator extension). Treat non-mac bugs as in-scope but possibly untested rather than out-of-scope.
+- **No code signing on Windows/Linux** — `signingIdentity: "-"` is macOS ad-hoc. Windows users hit SmartScreen on first launch; Linux AppImage/.deb is unsigned. Real signing certs aren't set up yet.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ Named after Eir, the Norse goddess of healing. The icon combines a watching eye 
 
 ## Features
 
-- **Menubar / system-tray only** — no taskbar entry; lives as a tray icon with a 380×520 popup (auto-expands to fill screen height on macOS)
+- **Menubar / system-tray only** — no taskbar entry; lives as a tray icon with a 440×680 popup (auto-expands to fill screen height on macOS)
 - **GitHub OAuth device flow** — sign in once, the token is stored in a per-user config file and survives restarts
 - **Grouped list** — PRs and Issues grouped by repository with sticky headers and per-repo unread counts
 - **Filter tabs** — All / Mine / Review Requests / Mentions / Hidden, backed by different GitHub search queries
-- **Auto-refresh** — silent background polling every 30s–5min (configurable)
-- **Native notifications** — desktop notifications when a new PR or Issue first appears (banner duration is set by the OS; on macOS, switch the style from *Banners* to *Alerts* under System Settings → Notifications → eir to keep them on screen until dismissed)
-- **Unread tracking** — macOS tray badge shows the unread count; Windows/Linux show it in the hover tooltip
-- **Global shortcut** — `Ctrl+Shift+E` toggles the popup from anywhere
+- **Per-repo overrides** — pin extra repos and toggle PRs/Issues inclusion per-repo, on top of global include settings
+- **Auto-refresh** — silent background polling (configurable interval), driven from Rust so updates keep flowing while the popup is hidden
+- **Native notifications** — desktop notifications when a new PR or Issue first appears, plus contextual reasons (new comments, CI failed, state changes); click a notification to open it in the browser. Banner duration is set by the OS; on macOS, switch the style from *Banners* to *Alerts* under System Settings → Notifications → eir to keep them on screen until dismissed.
+- **Unread tracking** — macOS tray badge shows the unread count with a red-dot icon variant; Windows/Linux show it in the hover tooltip
+- **Configurable global shortcut** — `Ctrl+Shift+E` by default; rebind from Settings
+- **In-app updater** — checks GitHub Releases on startup and from Settings, downloads the signed bundle, verifies its ed25519 signature, and relaunches
+- **Autostart** — optionally launch eir at login (macOS LaunchAgent / Windows registry / Linux .desktop)
 - **Light/dark aware** — template-mode tray icon on macOS and `prefers-color-scheme` styling everywhere
 
 ## Install
@@ -93,9 +96,14 @@ src/routes/+page.svelte       Single-page frontend (sign-in → list → setting
 src-tauri/src/
   lib.rs                      run(), plugins, window-focus handler
   auth.rs                     Device flow commands + cross-platform token file (mode-0600 on unix, %APPDATA% on Windows)
-  github.rs                   fetch_watched + query_for_tab
-  tray.rs                     Tray setup, toggle_popup, set_tray_badge
-  tauri.conf.json             Window config (380x520, hidden on launch, undecorated)
+  github.rs                   fetch_watched, fetch_notifications, fetch_item_states
+  background.rs               Long-lived Rust polling worker, diff detection, tray badge & notification emission
+  diff.rs                     Pure functions for "what changed" between two snapshots
+  tray.rs                     Tray setup, toggle_popup, set_tray_badge (template+badge on macOS, tooltip elsewhere)
+  shortcut.rs                 User-configurable global shortcut
+  updater.rs                  relaunch_app — macOS uses /usr/bin/open -n, others app.restart()
+  settings_io.rs              Read/write the settings JSON without plugin-fs
+  tauri.conf.json             Window config (440x680, hidden on launch, undecorated)
   icons/                      App & tray icons (tray-icon.png is template-mode)
 assets/icon-source/           Source PNGs used for icon generation
 ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.3",
-    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.3
         version: 2.5.3
-      '@tauri-apps/plugin-process':
-        specifier: ^2.3.1
-        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
@@ -208,42 +205,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -333,35 +324,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -400,9 +386,6 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
-
-  '@tauri-apps/plugin-process@2.3.1':
-    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -633,28 +616,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1215,10 +1194,6 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.3':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-process@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1118,7 +1118,6 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
- "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
 ]
@@ -5150,16 +5149,6 @@ dependencies = [
  "url",
  "windows",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
-dependencies = [
- "tauri",
- "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,6 @@ tauri-plugin-notification = "2.3.3"
 rustls = { version = "0.23.38", default-features = false, features = ["aws-lc-rs"] }
 tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-updater = "2.10.1"
-tauri-plugin-process = "2.3.1"
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-dialog = "2.7.0"
 # Used to synthesise the red-dot badge variant of the tray icon at startup.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,7 +9,6 @@
     "dialog:default",
     "notification:default",
     "updater:default",
-    "process:default",
     "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod github;
 mod settings_io;
 mod shortcut;
 mod tray;
+mod updater;
 
 use std::sync::Mutex;
 
@@ -27,7 +28,6 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_autostart::init(
             // On macOS we use the modern LaunchAgent; no extra CLI args.
             MacosLauncher::LaunchAgent,
@@ -64,6 +64,7 @@ pub fn run() {
             background::get_background_state,
             background::trigger_refresh,
             background::set_background_config,
+            updater::relaunch_app,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,37 @@
+use tauri::AppHandle;
+
+/// Restart eir after an in-place updater install.
+///
+/// `tauri_plugin_process::relaunch` (and `AppHandle::restart`) spawn
+/// `current_exe()` directly, which on macOS bypasses Launch Services. For an
+/// `ActivationPolicy::Accessory` menubar app — and especially right after the
+/// updater swapped the .app bundle on disk — that spawn silently fails: the
+/// old process exits and nothing shows up in the menubar. Going through
+/// `/usr/bin/open -n` re-enters Launch Services and reliably brings the new
+/// instance up.
+#[tauri::command]
+pub async fn relaunch_app(app: AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+        // exe = .../eir.app/Contents/MacOS/eir → three parents up is the bundle.
+        let bundle = exe
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.parent())
+            .ok_or_else(|| "could not resolve .app bundle path".to_string())?;
+
+        std::process::Command::new("/usr/bin/open")
+            .arg("-n")
+            .arg(bundle)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+
+        app.exit(0);
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        app.restart();
+    }
+}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -11,7 +11,6 @@
     | { kind: "up-to-date" }
     | { kind: "available"; update: Update }
     | { kind: "downloading" }
-    | { kind: "installed" }
     | { kind: "error"; message: string };
 
   type Props = {
@@ -247,8 +246,6 @@
           <span class="setting-hint-inline update-available"
             >· v{updateStatus.update.version} available</span
           >
-        {:else if updateStatus.kind === "installed"}
-          <span class="setting-hint-inline">· installed, relaunching…</span>
         {:else if updateStatus.kind === "error"}
           <span class="setting-hint-inline error-inline"
             >· {updateStatus.message}</span

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,6 @@
     requestPermission,
   } from "@tauri-apps/plugin-notification";
   import { check as checkForUpdate, Update } from "@tauri-apps/plugin-updater";
-  import { relaunch } from "@tauri-apps/plugin-process";
   import { ask, message, open, save } from "@tauri-apps/plugin-dialog";
   import {
     disable as disableAutostart,
@@ -144,7 +143,6 @@
     | { kind: "up-to-date" }
     | { kind: "available"; update: Update }
     | { kind: "downloading" }
-    | { kind: "installed" }
     | { kind: "error"; message: string };
   let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   let appVersion = $state<string>("");
@@ -349,8 +347,7 @@
       // install state.
       if (
         updateStatus.kind === "available" ||
-        updateStatus.kind === "downloading" ||
-        updateStatus.kind === "installed"
+        updateStatus.kind === "downloading"
       ) {
         return;
       }
@@ -378,8 +375,7 @@
     updateStatus = { kind: "downloading" };
     try {
       await update.downloadAndInstall();
-      updateStatus = { kind: "installed" };
-      await relaunch();
+      await invoke("relaunch_app");
     } catch (e) {
       const message = String(e);
       console.warn("[eir] update install failed:", message);


### PR DESCRIPTION
## Summary

- The auto-updater's relaunch path (via `tauri-plugin-process` / `AppHandle::restart`) spawns `current_exe()` directly. On macOS, an `ActivationPolicy::Accessory` menubar app launched this way bypasses Launch Services and silently fails to bring up a new menubar icon — especially right after the updater has swapped the .app bundle on disk. The old process exits, the new one never visibly starts, and the user has to relaunch from Finder.
- This swaps the relaunch path for a custom Rust command (\`updater::relaunch_app\`) that, on macOS, shells out to \`/usr/bin/open -n <bundle>\` so the new instance goes through Launch Services. Windows / Linux fall back to \`AppHandle::restart()\` (equivalent to what plugin-process did, no Launch Services analog needed).
- Drops the now-unused \`tauri-plugin-process\` dependency (Cargo + npm) and its \`process:default\` capability.
- Removes the unreachable \`updateStatus = { kind: \"installed\" }\` transition and its Settings UI — \`relaunch_app\` calls \`app.exit(0)\`, so the await never resolves and the state was never visible to users.
- Refreshes \`CLAUDE.md\` and \`README.md\` to reflect the current cross-platform status (CI builds all four targets, code branches exist for Windows/Linux, but macOS remains the primary test surface).

## Why

User reported: \"InstallUpdate した後に自動的に起動しないんだけど\". Reproduced — after the in-app updater finishes, the menubar icon disappears and the new process never shows up; launching \`eir.app\` manually works fine, confirming it's the relaunch handoff failing, not Gatekeeper or signing.

The fix matches the standard recommendation for Tauri menubar apps on macOS (go through \`open -n\` instead of spawning the binary directly).

## Test plan

- [ ] On macOS: install eir at the previous version, push a new release, trigger Check for updates → Install. App should disappear briefly and come back with the new version.
- [x] \`cargo check\` / \`cargo clippy --all-targets -- -D warnings\` / \`cargo test --lib\` all green
- [x] \`pnpm check\` (svelte-check, type) — 0 errors
- [x] \`pnpm test\` (vitest) — 46/46 passing
- [ ] CI passes (Linux/Windows builds will exercise the \`app.restart()\` branch in \`updater.rs\` at compile time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)