### PR TITLE
fix: Repository overrides で PR と Issue を両方チェックすると行が消える問題を修正

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -84,8 +84,10 @@ pub struct BackgroundState {
 }
 
 /// Per-repository override of which item kinds the user wants to see.
-/// `{prs: true, issues: true}` is the default and is never stored —
-/// repos without an override fall through to the global Include toggles.
+/// All four combinations are stored, including `{prs: true, issues: true}`:
+/// with a global Include toggle off it widens that kind back in for this repo,
+/// and either way it keeps the override row visible in the UI. Repos without
+/// an override fall through to the global Include toggles.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RepoSetting {
     pub prs: bool,
@@ -784,12 +786,10 @@ fn apply_background_config(s: &mut BackgroundState, config: BackgroundConfig) ->
         }
     }
     if let Some(next) = config.repo_settings {
-        // {prs:true, issues:true} entries are the implicit default and would
-        // otherwise force a generation bump on every round-trip through the UI.
-        let next: HashMap<String, RepoSetting> = next
-            .into_iter()
-            .filter(|(_, s)| !(s.prs && s.issues))
-            .collect();
+        // Every combination is kept, including {prs:true, issues:true}: with a
+        // global Include toggle off it widens that kind back in for the repo,
+        // and it keeps the override row visible in the UI. The map only changes
+        // on a genuine user edit, so this doesn't churn the generation.
         if next != s.repo_settings {
             // A widening override (global OFF + repo ON) changes the GraphQL
             // query, not just the client-side filter — invalidate anchors and
@@ -1367,12 +1367,12 @@ mod apply_background_config_tests {
     }
 
     #[test]
-    fn repo_settings_default_entries_are_pruned() {
-        // {prs:true, issues:true} is the implicit default and must not survive
-        // a round-trip — otherwise it would bump the generation for a no-op.
+    fn repo_settings_both_true_entries_are_kept() {
+        // {prs:true, issues:true} is a real override — with a global Include
+        // toggle off it widens both kinds back in for the repo, so it must
+        // survive a round-trip and stay visible rather than vanishing.
         let mut s = BackgroundState::new();
         seed_loaded_state(&mut s, Tab::All);
-        let before = s.config_generation;
 
         let mut next = HashMap::new();
         next.insert(
@@ -1390,9 +1390,14 @@ mod apply_background_config_tests {
             },
         );
 
-        assert!(!trigger);
-        assert_eq!(s.config_generation, before);
-        assert!(s.repo_settings.is_empty());
+        assert!(trigger);
+        assert_eq!(
+            s.repo_settings.get("o/r"),
+            Some(&RepoSetting {
+                prs: true,
+                issues: true,
+            })
+        );
     }
 
     #[test]

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -95,7 +95,7 @@ export function normalizeRepoSettingsInput(
     for (const [repo, val] of Object.entries(
       newShape as Record<string, unknown>,
     )) {
-      if (isValidRepoName(repo) && isRepoSetting(val) && !(val.prs && val.issues)) {
+      if (isValidRepoName(repo) && isRepoSetting(val)) {
         out[repo] = { prs: val.prs, issues: val.issues };
       }
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -812,10 +812,10 @@
   }
 
   function updateRepoOverride(repo: string, next: RepoSetting) {
-    if (next.prs && next.issues) {
-      removeRepoOverride(repo);
-      return;
-    }
+    // Keep the override even when both kinds are ticked. With a global Include
+    // toggle off, {prs:true, issues:true} widens both kinds back in for this
+    // repo; with both globals on it's a visible no-op the user asked to keep
+    // (use the × button to remove an override, not "check everything").
     repoSettings.set(repo, next);
     commitRepoSettings();
   }


### PR DESCRIPTION
## 概要

Repository overrides で repo の **PR と Issue を両方チェックすると override 行が消えてしまう** バグを修正します。

## 原因

`{prs:true, issues:true}` を「グローバル設定と同じ no-op だから保存しない」とみなして除外する処理が **3箇所** にありました:

- `src/routes/+page.svelte` `updateRepoOverride` — 両方 true なら `removeRepoOverride` を呼んで削除
- `src/lib/storage.ts` `normalizeRepoSettingsInput` — load 時に `!(val.prs && val.issues)` でフィルタ
- `src-tauri/src/background.rs` `apply_background_config` — 保存前に prune

しかし実際には no-op ではありません。`github.rs` の `widening_queries` は `wants_pr = s.prs && !include_prs` で判定しており、**グローバルの Include PRs を off にしている場合、`{prs:true, issues:true}` の override は「その repo だけ PR も Issue も追加検索で復活させる」有意味な設定**です。

つまり二重のバグでした:

1. **UX バグ(報告内容)**: 両方チェックすると行が消える
2. **機能バグ**: グローバル Include を off にしていると、特定 repo で PR・Issue 両方を復活させる override が作れない(2つ目をチェックした瞬間 override 全体が削除される)

## 変更内容

`{prs:true, issues:true}` を pruning していた 3箇所を削除し、4通り(`{T,T}` `{T,F}` `{F,T}` `{F,F}`)すべてを正規の設定として保持するようにしました。override の削除は × ボタンのみで行う一貫した挙動になります。`{F,F}`(repo 全体を非表示)は従来通りです。

- `apply_background_config` の prune フィルタ削除 + `RepoSetting` の doc コメント更新
- `normalizeRepoSettingsInput` の load 時フィルタ削除
- `updateRepoOverride` の「両方 true なら削除」分岐を削除
- pruning 前提だったテスト `repo_settings_default_entries_are_pruned` を `repo_settings_both_true_entries_are_kept` に書き換え

## 検証

- ✅ `cargo test --lib repo_settings` — 3件 pass
- ✅ `cargo clippy --all-targets -- -D warnings` — 警告なし
- ⏳ フロントエンド `pnpm test` / `pnpm check` — 実行環境の Node が v16.13.0 で pnpm の要求(v16.14+)を満たさず未実行。変更はトリビアルな TypeScript で、既存テストの対象範囲には影響なし

### レビュアー向け確認ポイント(実機 `pnpm tauri dev`)

- repo override で PR・Issue を両方チェックしても行が消えないこと
- グローバル Include PRs を off にした状態で、特定 repo の override で両方チェックすると、その repo の PR/Issue が一覧に復活すること
- × ボタンで override を削除できること(従来通り)

🤖 Generated with [Claude Code](https://claude.com/claude-code)