### PR TITLE
feat: snooze PRs and Issues with reminder notification

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -14,6 +14,7 @@ use crate::github::{
     build_octocrab, fetch_item_states_with, fetch_notifications_with, fetch_watched_with, ItemRef,
     LatestComment, NotificationItem, WatchedItem,
 };
+use crate::snooze::{self, SnoozedMap};
 
 pub const STATE_UPDATED_EVENT: &str = "state-updated";
 
@@ -81,6 +82,13 @@ pub struct BackgroundState {
     pub interval_ms: u64,
     pub include_prs: bool,
     pub include_issues: bool,
+
+    /// Item id → unix-seconds expiry. A snoozed item stays in the list but
+    /// is treated as read: it doesn't contribute to the unread count and any
+    /// diff signal against it is suppressed. When `until <= now()` the entry
+    /// is dropped and the worker fires a "Snooze ended" notification so the
+    /// user gets pinged exactly once at the expected time.
+    pub snoozed: SnoozedMap,
 }
 
 /// Per-repository override of which item kinds the user wants to see.
@@ -118,6 +126,7 @@ impl BackgroundState {
             interval_ms: DEFAULT_INTERVAL_MS,
             include_prs: true,
             include_issues: true,
+            snoozed: snooze::load_active(),
             ..Default::default()
         }
     }
@@ -205,6 +214,10 @@ pub struct StatePayload {
     pub loading: bool,
     pub last_error: Option<String>,
     pub authenticated: bool,
+    /// Item-id → expiry as unix epoch seconds. The frontend converts to
+    /// `Date` via `new Date(until * 1000)` for display; storing seconds
+    /// rather than ms keeps it consistent with how it lands on disk.
+    pub snoozed: HashMap<u64, i64>,
 }
 
 fn snapshot_payload(state: &BackgroundState) -> StatePayload {
@@ -214,6 +227,7 @@ fn snapshot_payload(state: &BackgroundState) -> StatePayload {
         loading: state.loading,
         last_error: state.last_error.clone(),
         authenticated: state.authenticated,
+        snoozed: state.snoozed.clone(),
     }
 }
 
@@ -236,7 +250,14 @@ fn update_tray_badge(app: &AppHandle, handle: &BackgroundHandle) {
         let mut has_unread = false;
         for i in visible {
             count += 1;
-            if !has_unread && notified_keys.contains(&item_key(&i.repo, i.kind, i.number)) {
+            // Snoozed items count toward the visible total (the row is still
+            // there) but never toward "unread" — that's the whole point of
+            // snooze: take the badge dot off the tray icon until the timer
+            // fires.
+            if !has_unread
+                && !s.snoozed.contains_key(&i.id)
+                && notified_keys.contains(&item_key(&i.repo, i.kind, i.number))
+            {
                 has_unread = true;
             }
         }
@@ -405,6 +426,13 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     // before any await so the state stays contended-free while fetching.
     // `generation` lets the write-back detect a tab/orgs change that landed
     // mid-cycle and discard stale anchors.
+    //
+    // Snooze housekeeping rides on the same lock acquisition: drain expired
+    // entries, persist the truncated map, and carry the expired IDs out so
+    // the post-fetch notification phase can fire "Snooze ended" for each.
+    // `snoozed_active` is the cloned map for the still-active entries —
+    // used downstream to suppress diff notifications for snoozed items.
+    let now = snooze::now_unix();
     let (
         tab,
         watched_orgs,
@@ -416,8 +444,12 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
         generation,
         include_prs,
         include_issues,
+        snoozed_active,
+        snooze_expired,
     ) = handle.with_state(|s| {
         s.loading = true;
+        let expired = snooze::drain_expired(&mut s.snoozed, now);
+        let snoozed_active = s.snoozed.clone();
         (
             s.tab,
             s.watched_orgs.clone(),
@@ -429,8 +461,13 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
             s.config_generation,
             s.include_prs,
             s.include_issues,
+            snoozed_active,
+            expired,
         )
     });
+    if !snooze_expired.is_empty() {
+        snooze::save(&snoozed_active);
+    }
     emit_state(app, handle);
 
     let octo = match build_octocrab(&token) {
@@ -539,10 +576,42 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
         .map(|i| (item_key(&i.repo, i.kind, i.number), i))
         .collect();
 
+    // Snoozed item keys for suppressing the fresh-thread notifications: the
+    // GitHub notification carries only (repo, kind, number), not the
+    // database id, so we materialise the keys of the currently-snoozed
+    // items here once.
+    let snoozed_keys: HashSet<String> = items
+        .iter()
+        .filter(|i| snoozed_active.contains_key(&i.id))
+        .map(|i| item_key(&i.repo, i.kind, i.number))
+        .collect();
+
+    // `Snooze ended` notifications fire even on the very first cycle after a
+    // restart: the user explicitly asked to be reminded at this time, so a
+    // boot that crosses the deadline must still ping them. The standard
+    // `has_loaded_once` gate (which guards against the first-cycle banner
+    // storm for fresh/item_changes/removed) is intentionally skipped here.
+    if notify_enabled {
+        for id in &snooze_expired {
+            let (title, body) = match items_by_key.values().find(|i| i.id == *id) {
+                Some(item) => (
+                    "Reminder".to_string(),
+                    format!("{}#{} — {}", item.repo, item.number, item.title),
+                ),
+                None => ("Reminder".to_string(), "Snoozed item is back".to_string()),
+            };
+            eprintln!("[eir] notify snooze-ended: id={id}");
+            send_os_notification(app, &title, &body);
+        }
+    }
+
     if has_loaded_once && notify_enabled {
         for n in &fresh {
             let Some(num) = n.number else { continue };
             let key = item_key(&n.repo, n.kind, num);
+            if snoozed_keys.contains(&key) {
+                continue;
+            }
             let title = build_title(&n.repo, n.kind, num, &n.title);
             // Only comment-driven reasons should render the latest-comment
             // body. CI / state / review-requested / assign reasons keep the
@@ -562,6 +631,9 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
             send_os_notification(app, &title, &body);
         }
         for ic in &item_changes {
+            if snoozed_active.contains_key(&ic.item.id) {
+                continue;
+            }
             let title = build_title(&ic.item.repo, ic.item.kind, ic.item.number, &ic.item.title);
             // Only `+N comment(s)` reasons should render the latest-comment
             // body. State transitions, CI changes, draft flips, reviewer
@@ -582,6 +654,13 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
             );
             send_os_notification(app, &title, &body);
         }
+        // A snoozed item that gets closed/merged would otherwise generate a
+        // `removed` ping — keep the snooze contract intact and silently drop
+        // those instead of pinging.
+        let removed: Vec<WatchedItem> = removed
+            .into_iter()
+            .filter(|i| !snoozed_active.contains_key(&i.id))
+            .collect();
         if !removed.is_empty() {
             let refs: Vec<ItemRef> = removed
                 .iter()
@@ -733,6 +812,41 @@ pub fn get_background_state(handle: tauri::State<'_, BackgroundHandle>) -> State
 #[tauri::command]
 pub fn trigger_refresh(handle: tauri::State<'_, BackgroundHandle>) {
     handle.trigger_refresh();
+}
+
+/// Snooze an item until `until` (unix epoch seconds). `until` in the past
+/// is rejected so a misformed picker can't accidentally re-fire the
+/// expiry notification on the very next cycle. The state-updated emit
+/// keeps the list UI in sync without a worker round-trip.
+#[tauri::command]
+pub fn snooze_item(
+    item_id: u64,
+    until: i64,
+    handle: tauri::State<'_, BackgroundHandle>,
+    app: AppHandle,
+) -> Result<(), String> {
+    if until <= snooze::now_unix() {
+        return Err("until must be in the future".into());
+    }
+    let snoozed_snapshot = handle.with_state(|s| {
+        s.snoozed.insert(item_id, until);
+        s.snoozed.clone()
+    });
+    snooze::save(&snoozed_snapshot);
+    emit_state(&app, &handle);
+    update_tray_badge(&app, &handle);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn unsnooze_item(item_id: u64, handle: tauri::State<'_, BackgroundHandle>, app: AppHandle) {
+    let snoozed_snapshot = handle.with_state(|s| {
+        s.snoozed.remove(&item_id);
+        s.snoozed.clone()
+    });
+    snooze::save(&snoozed_snapshot);
+    emit_state(&app, &handle);
+    update_tray_badge(&app, &handle);
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod diff;
 mod github;
 mod settings_io;
 mod shortcut;
+mod snooze;
 mod tray;
 mod updater;
 
@@ -64,6 +65,8 @@ pub fn run() {
             background::get_background_state,
             background::trigger_refresh,
             background::set_background_config,
+            background::snooze_item,
+            background::unsnooze_item,
             updater::relaunch_app,
         ])
         .setup(|app| {

--- a/src-tauri/src/snooze.rs
+++ b/src-tauri/src/snooze.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Snooze entry keyed by `WatchedItem::id`. `until_unix` is seconds since the
+/// Unix epoch — i64 so a far-future timestamp comparing against `now_unix()`
+/// can't silently wrap. RFC3339 strings would round-trip via the frontend
+/// just as well; integer seconds keep the on-disk JSON compact and the
+/// expiry check a trivial integer compare.
+pub type SnoozedMap = HashMap<u64, i64>;
+
+#[derive(Serialize, Deserialize, Default)]
+struct StoredSnoozed {
+    #[serde(flatten)]
+    items: HashMap<String, i64>,
+}
+
+/// Seconds-since-epoch reading of the current wall clock. Used everywhere
+/// expiry is checked so the same helper covers both the worker and the
+/// initial purge-on-load. A clock running backwards (NTP correction) would
+/// merely keep an entry alive a little longer — never resurrect a deleted
+/// one.
+pub fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// JSON file under a per-user config directory. Mirrors `auth::token_store` —
+/// see that module's comment for why the OS keychain isn't used. This file
+/// only ever contains item IDs + timestamps (no credentials), so default
+/// per-user perms are fine; we still write 0600 on unix for symmetry.
+///
+/// - macOS / Linux: `$HOME/.config/eir/snoozed.json`
+/// - Windows: `%APPDATA%\eir\snoozed.json`
+mod snooze_store {
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use super::{SnoozedMap, StoredSnoozed};
+
+    #[cfg(not(windows))]
+    fn path() -> Option<PathBuf> {
+        let home = std::env::var_os("HOME")?;
+        Some(
+            PathBuf::from(home)
+                .join(".config")
+                .join("eir")
+                .join("snoozed.json"),
+        )
+    }
+
+    #[cfg(windows)]
+    fn path() -> Option<PathBuf> {
+        let appdata = std::env::var_os("APPDATA")?;
+        Some(PathBuf::from(appdata).join("eir").join("snoozed.json"))
+    }
+
+    pub fn load() -> SnoozedMap {
+        let Some(p) = path() else {
+            return SnoozedMap::new();
+        };
+        let Ok(raw) = std::fs::read_to_string(&p) else {
+            return SnoozedMap::new();
+        };
+        let parsed: StoredSnoozed = serde_json::from_str(&raw).unwrap_or_default();
+        parsed
+            .items
+            .into_iter()
+            .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (id, v)))
+            .collect()
+    }
+
+    pub fn save(snoozed: &SnoozedMap) {
+        let Some(p) = path() else { return };
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let stored = StoredSnoozed {
+            items: snoozed.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
+        };
+        let Ok(json) = serde_json::to_string(&stored) else {
+            return;
+        };
+        if let Ok(mut file) = std::fs::File::create(&p) {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+            }
+            let _ = file.write_all(json.as_bytes());
+        }
+    }
+}
+
+/// Read the persisted snoozed map and immediately drop any already-expired
+/// entries before returning it. Called once at startup so a worker that
+/// boots after a long sleep doesn't have to re-fire the expiry purge.
+pub fn load_active() -> SnoozedMap {
+    let mut map = snooze_store::load();
+    let now = now_unix();
+    map.retain(|_, until| *until > now);
+    // Persist the purge so a future load doesn't keep re-reading the same
+    // already-expired entries.
+    snooze_store::save(&map);
+    map
+}
+
+pub fn save(snoozed: &SnoozedMap) {
+    snooze_store::save(snoozed);
+}
+
+/// Pull out the entries whose `until` has passed. The mutation happens on
+/// the caller's owned map so the worker can immediately reach for the
+/// returned IDs to fire "Snooze ended" notifications without re-acquiring
+/// the state lock.
+pub fn drain_expired(map: &mut SnoozedMap, now: i64) -> Vec<u64> {
+    let expired: Vec<u64> = map
+        .iter()
+        .filter_map(|(id, until)| (*until <= now).then_some(*id))
+        .collect();
+    for id in &expired {
+        map.remove(id);
+    }
+    expired
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_expired_removes_only_past_entries() {
+        let mut map: SnoozedMap = HashMap::new();
+        map.insert(1, 100);
+        map.insert(2, 200);
+        map.insert(3, 300);
+
+        let expired = drain_expired(&mut map, 200);
+
+        let mut sorted = expired.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![1, 2]);
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key(&3));
+    }
+
+    #[test]
+    fn drain_expired_no_op_when_nothing_due() {
+        let mut map: SnoozedMap = HashMap::new();
+        map.insert(1, 500);
+        map.insert(2, 600);
+
+        let expired = drain_expired(&mut map, 100);
+
+        assert!(expired.is_empty());
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn drain_expired_empty_map_returns_empty() {
+        let mut map: SnoozedMap = HashMap::new();
+        let expired = drain_expired(&mut map, 100);
+        assert!(expired.is_empty());
+    }
+}

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -24,6 +24,17 @@
     unreadOnly: boolean;
     viewMode: ViewMode;
     showLatestComment: boolean;
+    /// Item-id → unix epoch seconds the snooze expires at. Sourced from the
+    /// Rust worker; the component only reads, mutations go through the
+    /// onSnoozeItem / onUnsnoozeItem callbacks below.
+    snoozedUntil: Record<number, number>;
+    /// Current wall-clock in unix seconds, refreshed by the host so the
+    /// countdown labels can re-render without each row owning a timer.
+    nowSec: number;
+    /// Item id whose Snooze menu should be open, owned by the host so a
+    /// keyboard shortcut on the page can open the menu for the currently-
+    /// selected row. Pass `null` to close.
+    snoozeMenuOpenId: number | null;
     onRefresh: () => void;
     onMarkAllVisibleAsRead: () => void;
     onShowSettings: () => void;
@@ -33,6 +44,8 @@
     onHideItem: (id: number) => void;
     onUnhideItem: (id: number) => void;
     onTogglePin: (id: number) => void;
+    onSnoozeItem: (id: number, untilSec: number) => void;
+    onUnsnoozeItem: (id: number) => void;
     onClearSearch: () => void;
     onCloseSearch: () => void;
     onToggleUnreadOnly: () => void;
@@ -55,6 +68,9 @@
     unreadOnly,
     viewMode,
     showLatestComment,
+    snoozedUntil,
+    nowSec,
+    snoozeMenuOpenId = $bindable(),
     onRefresh,
     onMarkAllVisibleAsRead,
     onShowSettings,
@@ -64,11 +80,243 @@
     onHideItem,
     onUnhideItem,
     onTogglePin,
+    onSnoozeItem,
+    onUnsnoozeItem,
     onClearSearch,
     onCloseSearch,
     onToggleUnreadOnly,
     onSetViewMode,
   }: Props = $props();
+
+  // `snoozeMenuOpenId` is bindable from the host so a keyboard shortcut
+  // can drive it. Custom-mode fields stay local since they're only
+  // meaningful while a menu is open; a $effect below resets them whenever
+  // the host closes the menu and seeds defaults when one opens.
+  let customMode = $state(false);
+  // Date stays as `<input type="date">` (browser handles locale fine).
+  // Time is split into two `<input type="number">` fields because macOS
+  // WebKit ignores the `lang` attribute on `<input type="time">` and
+  // always renders the locale's 12h/24h widget — so a US-locale user
+  // ends up with an "AM/PM" picker no matter what. Two number fields
+  // give us a deterministic 24h interface that doesn't depend on the
+  // user's OS settings.
+  let customDate = $state("");
+  let customHourStr = $state("");
+  let customMinuteStr = $state("");
+  let lastMenuId = $state<number | null>(null);
+  /// Reference to the currently-rendered Snooze menu so the focus-management
+  /// effect can query it for focusable children. Only one menu is open at a
+  /// time, so a single ref is enough.
+  let menuRef = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    if (snoozeMenuOpenId !== lastMenuId) {
+      if (snoozeMenuOpenId != null) {
+        customMode = false;
+        seedCustomDefaults();
+      } else {
+        customMode = false;
+        customDate = "";
+        customHourStr = "";
+        customMinuteStr = "";
+      }
+      lastMenuId = snoozeMenuOpenId ?? null;
+    }
+  });
+
+  /// Action that focuses the first usable child of the menu when it
+  /// mounts, and again when `customMode` flips. A `use:` action is more
+  /// reliable here than a `$effect`: actions fire after the node and its
+  /// children are fully attached to the DOM, whereas an effect that reads
+  /// `menuRef` may run before `bind:this` has wired it up, leaving the
+  /// `s` shortcut with no focus transfer.
+  function focusMenuFirst(node: HTMLDivElement, mode: boolean) {
+    let current = mode;
+    function focusInner() {
+      queueMicrotask(() => {
+        if (!node.isConnected) return;
+        const target = current
+          ? node.querySelector<HTMLElement>("input")
+          : node.querySelector<HTMLButtonElement>("button:not(:disabled)");
+        target?.focus();
+      });
+    }
+    focusInner();
+    return {
+      update(newMode: boolean) {
+        current = newMode;
+        focusInner();
+      },
+    };
+  }
+
+  /// Bubble-phase keydown handler on the menu container. Stops Enter and
+  /// arrow keys from reaching the page-level shortcut handler (which would
+  /// otherwise fire `openSelected` on Enter, or move the list selection on
+  /// arrows). Arrow keys walk between preset buttons; the native time/date
+  /// inputs handle their own arrow-key spinning.
+  function handleMenuKey(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.stopPropagation();
+      return;
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.stopPropagation();
+      // Date/time inputs use arrows to change values; don't hijack.
+      if (e.target instanceof HTMLInputElement) return;
+      e.preventDefault();
+      moveMenuFocus(e.key === "ArrowDown" ? 1 : -1);
+    }
+  }
+
+  function moveMenuFocus(delta: 1 | -1) {
+    if (!menuRef) return;
+    const buttons = Array.from(
+      menuRef.querySelectorAll<HTMLButtonElement>("button:not(:disabled)"),
+    );
+    if (buttons.length === 0) return;
+    const active = document.activeElement;
+    const idx =
+      active instanceof HTMLButtonElement ? buttons.indexOf(active) : -1;
+    const next =
+      idx === -1 ? 0 : (idx + delta + buttons.length) % buttons.length;
+    buttons[next].focus();
+  }
+
+  function closeSnoozeMenu() {
+    snoozeMenuOpenId = null;
+  }
+
+  function toggleSnoozeMenu(id: number) {
+    if (snoozeMenuOpenId === id) {
+      closeSnoozeMenu();
+    } else {
+      snoozeMenuOpenId = id;
+    }
+  }
+
+  /// Seed both pickers with "1 hour from now" so opening custom mode lets
+  /// the user nudge a sensible default rather than type from scratch.
+  function seedCustomDefaults() {
+    const d = new Date(Date.now() + 60 * 60 * 1000);
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    customDate = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    customHourStr = pad(d.getHours());
+    customMinuteStr = pad(d.getMinutes());
+  }
+
+  /// Today's date as `YYYY-MM-DD`, used as the `min` on the date input so
+  /// the native picker greys out past calendar days.
+  function todayLocalIso(): string {
+    const d = new Date();
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+
+  /// Combine date + hour + minute into unix seconds. Returns `null` for
+  /// blank, out-of-range, or already-past values so the apply button can
+  /// disable itself instead of silently no-opping on click. Hour and
+  /// minute come in as strings so an empty input doesn't coerce to
+  /// `NaN` mid-edit.
+  function customUntilSec(): number | null {
+    if (!customDate) return null;
+    if (!customHourStr || !customMinuteStr) return null;
+    const h = Number.parseInt(customHourStr, 10);
+    const m = Number.parseInt(customMinuteStr, 10);
+    if (!Number.isFinite(h) || h < 0 || h > 23) return null;
+    if (!Number.isFinite(m) || m < 0 || m > 59) return null;
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    const t = new Date(`${customDate}T${pad(h)}:${pad(m)}`).getTime();
+    if (!Number.isFinite(t)) return null;
+    const sec = Math.floor(t / 1000);
+    if (sec <= Math.floor(Date.now() / 1000)) return null;
+    return sec;
+  }
+
+  /// Next occurrence of 8 AM local time, used by the "Tomorrow 8 AM" preset.
+  /// If it's currently before 8 AM the same calendar day's 8 AM wins; this
+  /// matches what users expect when snoozing late at night.
+  function nextMorningEightSec(): number {
+    const d = new Date();
+    const target = new Date(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate(),
+      8,
+      0,
+      0,
+      0,
+    );
+    if (target.getTime() <= d.getTime()) {
+      target.setDate(target.getDate() + 1);
+    }
+    return Math.floor(target.getTime() / 1000);
+  }
+
+  function pickPreset(id: number, addSeconds: number) {
+    const target = Math.floor(Date.now() / 1000) + addSeconds;
+    onSnoozeItem(id, target);
+    closeSnoozeMenu();
+  }
+
+  function pickMorning(id: number) {
+    onSnoozeItem(id, nextMorningEightSec());
+    closeSnoozeMenu();
+  }
+
+  function applyCustom(id: number) {
+    const sec = customUntilSec();
+    if (sec == null) return;
+    onSnoozeItem(id, sec);
+    closeSnoozeMenu();
+  }
+
+  function clearSnooze(id: number) {
+    onUnsnoozeItem(id);
+    closeSnoozeMenu();
+  }
+
+  /// Short, human-friendly remaining-time label for a snoozed row. We round
+  /// down so a row labelled "1h 0m" doesn't disappear into the past while
+  /// reading; the actual expiry is the Rust worker's responsibility.
+  function snoozeLabel(untilSec: number, now: number): string {
+    const delta = Math.max(0, untilSec - now);
+    if (delta < 60) return `${delta}s`;
+    const minutes = Math.floor(delta / 60);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const remMinutes = minutes % 60;
+    if (hours < 24) {
+      return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+    }
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return remHours > 0 ? `${days}d ${remHours}h` : `${days}d`;
+  }
+
+  // Close the Snooze menu on Escape or a click outside its wrapper. Using a
+  // global listener keeps the menu lifecycle out of every row's hover state
+  // — opening one and clicking anywhere else just dismisses it.
+  $effect(() => {
+    if (snoozeMenuOpenId == null) return;
+    function onDocMouseDown(e: MouseEvent) {
+      const target = e.target as Element | null;
+      if (target?.closest(".snooze-wrap")) return;
+      closeSnoozeMenu();
+    }
+    function onDocKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        closeSnoozeMenu();
+        e.stopPropagation();
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onDocKey, true);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onDocKey, true);
+    };
+  });
 
   const VIEW_MODES: { id: ViewMode; label: string; title: string }[] = [
     { id: "grouped", label: "Repo", title: "Group by repository" },
@@ -287,6 +535,7 @@
                 class:unread={notificationsByKey.has(itemKey(item))}
                 class:selected={item.id === selectedId}
                 class:draft={item.is_draft}
+                class:snoozed={snoozedUntil[item.id] != null}
                 onclick={() => onOpenItem(item)}
               >
                 <span class="badge" class:pr={item.kind === "pr"}>
@@ -328,6 +577,19 @@
                         title="CI: {item.ci_status}"
                       >
                         {#if item.ci_status === "success"}✓{:else if item.ci_status === "failure" || item.ci_status === "error"}✗{:else}⏱{/if}
+                      </span>
+                    {/if}
+                    {#if snoozedUntil[item.id] != null}
+                      <span class="sep">·</span>
+                      <span
+                        class="snooze-chip"
+                        title={"Snoozed until " +
+                          new Date(snoozedUntil[item.id] * 1000).toLocaleString(
+                            undefined,
+                            { hour12: false },
+                          )}
+                      >
+                        💤 {snoozeLabel(snoozedUntil[item.id], nowSec)}
                       </span>
                     {/if}
                   </span>
@@ -428,6 +690,145 @@
                       />
                     </svg>
                   </button>
+                  <div class="snooze-wrap">
+                    <button
+                      class="row-action snooze-btn"
+                      class:active={snoozedUntil[item.id] != null}
+                      onclick={() => toggleSnoozeMenu(item.id)}
+                      title={snoozedUntil[item.id] != null ? "Edit snooze" : "Snooze"}
+                      aria-label={snoozedUntil[item.id] != null ? "Edit snooze" : "Snooze"}
+                      aria-haspopup="menu"
+                      aria-expanded={snoozeMenuOpenId === item.id}
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <circle cx="12" cy="13" r="8" />
+                        <path d="M12 9v4l2.5 2" />
+                        <path d="M5 3 2 6" />
+                        <path d="m22 6-3-3" />
+                      </svg>
+                    </button>
+                    {#if snoozeMenuOpenId === item.id}
+                      <div
+                        bind:this={menuRef}
+                        use:focusMenuFirst={customMode}
+                        class="snooze-menu"
+                        class:custom={customMode}
+                        role="menu"
+                        aria-label="Snooze options"
+                        tabindex="-1"
+                        onkeydown={handleMenuKey}
+                      >
+                        {#if !customMode}
+                          <button
+                            class="snooze-option"
+                            role="menuitem"
+                            onclick={() => pickPreset(item.id, 30 * 60)}
+                          >
+                            30 minutes
+                          </button>
+                          <button
+                            class="snooze-option"
+                            role="menuitem"
+                            onclick={() => pickPreset(item.id, 60 * 60)}
+                          >
+                            1 hour
+                          </button>
+                          <button
+                            class="snooze-option"
+                            role="menuitem"
+                            onclick={() => pickMorning(item.id)}
+                          >
+                            Tomorrow 8 AM
+                          </button>
+                          <button
+                            class="snooze-option"
+                            role="menuitem"
+                            onclick={() => (customMode = true)}
+                          >
+                            Pick date &amp; time…
+                          </button>
+                          {#if snoozedUntil[item.id] != null}
+                            <button
+                              class="snooze-option danger"
+                              role="menuitem"
+                              onclick={() => clearSnooze(item.id)}
+                            >
+                              Clear snooze
+                            </button>
+                          {/if}
+                        {:else}
+                          <div class="snooze-custom-header">
+                            Wake at
+                          </div>
+                          <div class="snooze-custom-fields">
+                            <label class="snooze-custom-field">
+                              <span>Date</span>
+                              <input
+                                type="date"
+                                class="snooze-custom-input"
+                                min={todayLocalIso()}
+                                bind:value={customDate}
+                              />
+                            </label>
+                            <label class="snooze-custom-field">
+                              <span>Time (24h)</span>
+                              <div class="snooze-time-pair">
+                                <input
+                                  type="number"
+                                  class="snooze-custom-input snooze-time-input"
+                                  min="0"
+                                  max="23"
+                                  step="1"
+                                  inputmode="numeric"
+                                  aria-label="Hour"
+                                  bind:value={customHourStr}
+                                />
+                                <span class="snooze-time-sep">:</span>
+                                <input
+                                  type="number"
+                                  class="snooze-custom-input snooze-time-input"
+                                  min="0"
+                                  max="59"
+                                  step="1"
+                                  inputmode="numeric"
+                                  aria-label="Minute"
+                                  bind:value={customMinuteStr}
+                                />
+                              </div>
+                            </label>
+                          </div>
+                          {#if customUntilSec() == null && customDate && customHourStr && customMinuteStr}
+                            <div class="snooze-custom-error">
+                              Pick a future time.
+                            </div>
+                          {/if}
+                          <div class="snooze-custom-actions">
+                            <button
+                              class="snooze-option subtle"
+                              onclick={() => (customMode = false)}
+                            >
+                              Back
+                            </button>
+                            <button
+                              class="snooze-option primary"
+                              disabled={customUntilSec() == null}
+                              onclick={() => applyCustom(item.id)}
+                            >
+                              Snooze
+                            </button>
+                          </div>
+                        {/if}
+                      </div>
+                    {/if}
+                  </div>
                   <button
                     class="row-action"
                     onclick={() => onHideItem(item.id)}
@@ -1099,5 +1500,216 @@
     font-weight: 600;
     margin-right: 4px;
     opacity: 0.95;
+  }
+
+  /* Snoozed rows are still visible — just muted. The unread dot is already
+     suppressed via notificationsByKey on the host side, so all we need
+     here is to soften the text/badge so the eye skips past it until the
+     timer fires. */
+  .item.snoozed .title-text,
+  .item.snoozed .meta,
+  .item.snoozed .badge {
+    opacity: 0.55;
+  }
+
+  .snooze-chip {
+    flex-shrink: 0;
+    padding: 0 4px;
+    border-radius: 6px;
+    background: var(--neutral-bg);
+    color: var(--neutral);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Wrapper anchors the absolutely-positioned menu to the snooze button so
+     dropping it open in the rightmost column doesn't reflow the row. */
+  .snooze-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .snooze-btn svg {
+    width: 12px;
+    height: 12px;
+    display: block;
+  }
+
+  .snooze-btn.active {
+    visibility: visible;
+    pointer-events: auto;
+    color: var(--accent);
+  }
+
+  /* Menu hangs to the LEFT of the button so it doesn't run off the popup's
+     right edge. The popup window is fixed at 440px wide; a menu opening
+     rightward would be clipped. */
+  .snooze-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    min-width: 160px;
+    padding: 4px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: var(--bg);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  /* Custom mode opens the menu wider so the date/time picker controls
+     don't have to shrink — the native calendar dropdown that hangs off
+     `<input type="date">` is already as small as WebKit allows. */
+  .snooze-menu.custom {
+    min-width: 260px;
+    padding: 8px;
+    gap: 6px;
+  }
+
+  .snooze-option {
+    padding: 7px 10px;
+    font-size: 12px;
+    text-align: left;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .snooze-option:hover {
+    background: var(--hover-bg);
+  }
+
+  .snooze-option:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .snooze-option.danger {
+    color: var(--danger);
+    border-top: 1px solid var(--border-subtle);
+    margin-top: 2px;
+    padding-top: 6px;
+  }
+
+  .snooze-option.danger:hover {
+    background: var(--danger-bg);
+  }
+
+  .snooze-option.primary {
+    background: var(--accent-bg);
+    color: var(--accent);
+    font-weight: 600;
+    text-align: center;
+  }
+
+  .snooze-option.primary:hover:not(:disabled) {
+    background: var(--accent-bg-hover, var(--accent-bg));
+  }
+
+  .snooze-option.subtle {
+    color: var(--fg-muted);
+    text-align: center;
+  }
+
+  .snooze-custom-header {
+    padding: 2px 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .snooze-custom-fields {
+    display: flex;
+    gap: 8px;
+  }
+
+  .snooze-custom-field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  /* Bigger than the preset rows: this is the field the user is actively
+     editing, and the native date/time controls render their internal
+     spin/picker chrome at the input's font-size, so undersized fields
+     make the popup widget tiny. */
+  .snooze-custom-input {
+    padding: 7px 8px;
+    font-size: 13px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    background: var(--surface-2);
+    color: inherit;
+    font-family: inherit;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .snooze-custom-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  /* Two-field 24h time picker. Each input is centred and roomy enough
+     for two digits; the separator is purely visual. Keyboard up/down on
+     a number input cycles its value, so we hide the native spinner
+     chrome (it's tiny and ugly on WebKit) to keep the boxes clean. */
+  .snooze-time-pair {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .snooze-time-input {
+    flex: 1;
+    min-width: 0;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+
+  .snooze-time-input::-webkit-inner-spin-button,
+  .snooze-time-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  .snooze-time-sep {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    flex-shrink: 0;
+  }
+
+  .snooze-custom-error {
+    padding: 2px 4px;
+    font-size: 11px;
+    color: var(--danger);
+  }
+
+  .snooze-custom-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 2px;
+  }
+
+  .snooze-custom-actions .snooze-option {
+    flex: 1;
   }
 </style>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -480,6 +480,26 @@
           <dd><kbd>Enter</kbd></dd>
         </div>
         <div class="shortcut-item">
+          <dt>Snooze selected</dt>
+          <dd><kbd>S</kbd></dd>
+        </div>
+        <div class="shortcut-item">
+          <dt>Pin / unpin selected</dt>
+          <dd><kbd>P</kbd></dd>
+        </div>
+        <div class="shortcut-item">
+          <dt>Hide / unhide selected</dt>
+          <dd><kbd>H</kbd></dd>
+        </div>
+        <div class="shortcut-item">
+          <dt>Unread only</dt>
+          <dd><kbd>U</kbd></dd>
+        </div>
+        <div class="shortcut-item">
+          <dt>Toggle view (grouped / recent)</dt>
+          <dd><kbd>R</kbd></dd>
+        </div>
+        <div class="shortcut-item">
           <dt>Scroll</dt>
           <dd>
             <kbd>PageUp</kbd> <kbd>PageDown</kbd> <kbd>Home</kbd> <kbd>End</kbd>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -112,6 +112,19 @@
     window.matchMedia("(prefers-color-scheme: dark)").matches,
   );
   let notifications = $state<NotificationItem[]>([]);
+  // Item-id → unix epoch seconds the snooze expires at. Mirrored from the
+  // Rust worker via `state-updated`; the frontend never writes to this map
+  // directly (use the `snooze_item` / `unsnooze_item` commands instead).
+  let snoozedUntil = $state<Record<number, number>>({});
+  // Wall-clock tick that drives countdown labels on snoozed rows. Updated
+  // every 30s — the labels round to the minute so anything tighter would
+  // just burn CPU without visibly changing.
+  let nowSec = $state<number>(Math.floor(Date.now() / 1000));
+  // The currently-open Snooze menu, owned here so the `s` shortcut can
+  // toggle it for the selected row. Also auto-clears below when the item
+  // disappears (closed/merged/filter change) so a stale id can't reopen
+  // the menu on a future row that happens to recycle the same id.
+  let snoozeMenuOpenId = $state<number | null>(null);
   let toggleShortcut = $state<string>("Ctrl+Shift+E");
   let capturingShortcut = $state(false);
   let shortcutError = $state<string | null>(null);
@@ -167,6 +180,7 @@
   let systemThemeMedia: MediaQueryList | null = null;
   let systemThemeListener: ((e: MediaQueryListEvent) => void) | null = null;
   let updateCheckTimer: ReturnType<typeof setInterval> | null = null;
+  let snoozeTickTimer: ReturnType<typeof setInterval> | null = null;
 
   $effect(() => {
     const resolved =
@@ -174,16 +188,41 @@
     document.documentElement.setAttribute("data-theme", resolved);
   });
 
+  // Close the Snooze menu if its target item is no longer in the list (the
+  // PR got merged/closed, the user switched tabs, etc). Without this an
+  // orphaned id could reopen the menu on a future row that happens to
+  // collide with it.
+  $effect(() => {
+    if (snoozeMenuOpenId == null) return;
+    if (!items.some((i) => i.id === snoozeMenuOpenId)) {
+      snoozeMenuOpenId = null;
+    }
+  });
+
   function onThemeChange(value: Theme) {
     theme = value;
     persistTheme(value);
   }
+
+  // Lookup item-id by item_key so notificationsByKey can omit threads whose
+  // matching list item is currently snoozed. The pairing is repo+kind+number
+  // → id, matching how the Rust side builds item_key.
+  const itemIdByKey = $derived.by(() => {
+    const m = new Map<string, number>();
+    for (const i of items) m.set(itemKey(i), i.id);
+    return m;
+  });
 
   const notificationsByKey = $derived.by(() => {
     const m = new Map<string, NotificationItem[]>();
     for (const n of notifications) {
       if (n.number == null) continue;
       const k = itemKey({ repo: n.repo, kind: n.kind, number: n.number });
+      // Snoozed items are treated as read until the timer fires — drop their
+      // notifications from the lookup so the unread dot, the per-repo
+      // counter, and the toolbar's "Mark all visible as read" all skip them.
+      const id = itemIdByKey.get(k);
+      if (id != null && snoozedUntil[id] != null) continue;
       const existing = m.get(k);
       if (existing) existing.push(n);
       else m.set(k, [n]);
@@ -197,12 +236,18 @@
     loading: boolean;
     last_error: string | null;
     authenticated: boolean;
+    /// Item-id → unix epoch seconds (the moment the snooze expires). The
+    /// worker is the single source of truth for snooze state — the frontend
+    /// just renders what arrives here and calls `snooze_item` /
+    /// `unsnooze_item` on user action.
+    snoozed: Record<number, number>;
   };
 
   function applyState(payload: StatePayload) {
     items = payload.items;
     notifications = payload.notifications;
     loading = payload.loading;
+    snoozedUntil = payload.snoozed ?? {};
     if (payload.authenticated) {
       // Don't knock the UI out of the device-flow "pending" phase; the
       // worker briefly emits authenticated=false while the token is being
@@ -447,6 +492,11 @@
 
     void runUpdateCheck({ interactive: false });
     startUpdateCheckTimer();
+    // Drive snooze countdown labels. The worker also fires the actual expiry
+    // notification on its own polling cadence, so this is purely cosmetic.
+    snoozeTickTimer = setInterval(() => {
+      nowSec = Math.floor(Date.now() / 1000);
+    }, 30_000);
 
     // Kick the permission dialog early so the first real notification isn't
     // also the first time the OS is asked — which silently denies in some
@@ -478,6 +528,10 @@
     systemThemeMedia = null;
     systemThemeListener = null;
     stopUpdateCheckTimer();
+    if (snoozeTickTimer != null) {
+      clearInterval(snoozeTickTimer);
+      snoozeTickTimer = null;
+    }
   });
 
   function handleVisibilityChange() {
@@ -562,6 +616,32 @@
       key: "r",
       when: inLoadedPage,
       run: toggleViewMode,
+    },
+    {
+      key: "s",
+      when: inLoadedPage,
+      run: () => {
+        if (selectedId == null) return;
+        // Toggle: pressing `s` again on the same row closes the menu.
+        snoozeMenuOpenId =
+          snoozeMenuOpenId === selectedId ? null : selectedId;
+      },
+    },
+    {
+      key: "p",
+      when: inLoadedPage,
+      run: () => {
+        if (selectedId != null) togglePin(selectedId);
+      },
+    },
+    {
+      key: "h",
+      when: inLoadedPage,
+      run: () => {
+        if (selectedId == null) return;
+        if (activeTab === "hidden") unhideItem(selectedId);
+        else hideItem(selectedId);
+      },
     },
   ];
 
@@ -787,6 +867,22 @@
       pinnedItems.add(id);
     }
     persistPinnedItems(pinnedItems);
+  }
+
+  async function snoozeItem(id: number, untilSec: number) {
+    try {
+      await invoke("snooze_item", { itemId: id, until: untilSec });
+    } catch (e) {
+      console.warn("[eir] snooze_item failed:", e);
+    }
+  }
+
+  async function unsnoozeItem(id: number) {
+    try {
+      await invoke("unsnooze_item", { itemId: id });
+    } catch (e) {
+      console.warn("[eir] unsnooze_item failed:", e);
+    }
   }
 
   function commitRepoSettings() {
@@ -1295,6 +1391,9 @@
       {unreadOnly}
       {viewMode}
       {showLatestComment}
+      {snoozedUntil}
+      {nowSec}
+      bind:snoozeMenuOpenId
       bind:searchQuery
       onRefresh={triggerRefresh}
       onMarkAllVisibleAsRead={markAllVisibleAsRead}
@@ -1305,6 +1404,8 @@
       onHideItem={hideItem}
       onUnhideItem={unhideItem}
       onTogglePin={togglePin}
+      onSnoozeItem={snoozeItem}
+      onUnsnoozeItem={unsnoozeItem}
       onClearSearch={clearSearch}
       onCloseSearch={closeSearch}
       onToggleUnreadOnly={toggleUnreadOnly}


### PR DESCRIPTION
## Summary

- Add per-item Snooze for PR/Issue rows. While snoozed, an item stays in the list but is treated as read (no unread dot, no banners, no tray-badge contribution). When the timer expires the background worker drops the entry, fires a `Reminder` notification, and the item resumes normal unread behavior on the next change.
- Persist snooze state to `$HOME/.config/eir/snoozed.json` (or `%APPDATA%\eir\snoozed.json` on Windows) keyed by item id with unix-seconds expiry, following the same plain-file pattern as `token_store`. Worker owns expiry detection — the frontend's 30 s countdown is cosmetic.
- New keyboard shortcuts on the selected row: `s` (open snooze menu), `p` (pin/unpin), `h` (hide/unhide). Inside the snooze menu, `↑`/`↓` walks options, `Enter` selects, `Esc` closes.
- Custom snooze uses split `Date` + 24-hour `HH:MM` number inputs because macOS WebKit ignores `lang` on `<input type="time">` and would otherwise render an AM/PM widget.

## What changed

**Rust side**
- New `snooze.rs` module: `SnoozedMap = HashMap<u64, i64>`, `load_active` (load + purge expired + persist), `save`, `drain_expired`, plus unit tests for the drain logic.
- `BackgroundState` gains a `snoozed` field, seeded from `load_active()` at construction.
- `run_cycle` drains expired entries at cycle start, fires `Reminder` notifications for them, and filters fresh-notifications / item-change / removed paths so snoozed items are silent. Tray badge also excludes snoozed items from the unread count.
- New Tauri commands: `snooze_item(item_id, until)` (rejects past `until`), `unsnooze_item(item_id)`.
- `StatePayload.snoozed: HashMap<u64, i64>` ships the active map to the frontend on every emit.

**Frontend**
- `+page.svelte` owns `snoozeMenuOpenId` so the `s` shortcut can drive the menu open for the selected row. A `$effect` auto-clears the id when the underlying item disappears from `items`.
- `ItemList.svelte` renders the menu with presets (30 min / 1 hour / Tomorrow 8 AM / Pick date & time… / Clear snooze) and a custom panel with date + hour + minute number inputs. A `use:focusMenuFirst` action moves focus into the menu on open so arrow keys navigate options instead of the list. The menu's `onkeydown` stops Enter from bubbling to the page handler — fixes the bug where pressing Enter on "Snooze" in custom mode would also open the PR in a browser.
- `notificationsByKey` skips snoozed items so the unread dot, per-repo unread pill, and Mark-all-visible all treat them as read.

## Test plan

- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] `cd src-tauri && cargo test --lib` — 124 passed (incl. new `snooze::tests::drain_expired_*`)
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm test` — 46 passed
- [ ] Manual: `pnpm tauri dev`, snooze a PR for 30 min via mouse, then via `s` shortcut, then via Custom… → verify the item dims, unread dot disappears, tray count drops. Wait for short snooze to expire → verify Reminder notification fires.
- [ ] Manual: open custom picker, confirm Time fields show as plain 24-hour `HH : MM` regardless of macOS locale (no AM/PM widget).
- [ ] Manual: select a row, press `s` → menu opens with first option focused, `↓` walks options, `Enter` applies, `Esc` cancels. Press `Enter` on the Snooze button in custom mode and confirm the PR does **not** open.
- [ ] Manual: sign out / sign back in → `~/.config/eir/snoozed.json` survives across sessions (intentional — known follow-up for cross-account safety).

## Known follow-ups (from code review)

Out of scope for this PR but worth tracking separately:

- Reminder lost if the cycle's fetch fails right after `drain_expired` persists the empty map.
- `snooze.json` writes are non-atomic (`File::create` truncate); concurrent saves can corrupt JSON.
- `reset_session` doesn't clear the snoozed map on sign-out (cross-account collision risk).
- Mid-cycle snooze race: a `snooze_item` call during an in-flight cycle can still trigger a notification for the just-snoozed item.
- `snoozed_keys` is built from the current tab's `items` only, so a snoozed item that doesn't appear in the active tab's query can leak a fresh notification.
- `BackgroundState::new()` reads/writes the real `~/.config/eir/snoozed.json` from inside unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)