### PR TITLE
Add opt-in auth diagnostics log

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
 name = "eir"
 version = "0.16.0"
 dependencies = [
+ "chrono",
  "image",
  "octocrab",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,4 +35,7 @@ tauri-plugin-dialog = "2.7.0"
 # Tauri already pulls `image` in via the `image-png` feature, but we list it
 # explicitly so the direct API usage has its own version pin.
 image = { version = "0.25", default-features = false, features = ["png"] }
+# Human-readable UTC timestamps for the auth diagnostics log. Already in the
+# tree transitively (via octocrab); listed directly for the explicit usage.
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -80,6 +80,45 @@ mod token_store {
             let _ = std::fs::remove_file(p);
         }
     }
+
+    /// Non-sensitive snapshot of the token file for the diagnostics log: which
+    /// base env var resolved, the resolved path, and whether the file exists /
+    /// is non-empty. Never includes the token value itself.
+    pub fn diagnostic_probe() -> String {
+        #[cfg(not(windows))]
+        let (env_name, env_val) = ("HOME", std::env::var_os("HOME"));
+        #[cfg(windows)]
+        let (env_name, env_val) = ("APPDATA", std::env::var_os("APPDATA"));
+
+        let env_repr = match env_val {
+            Some(v) => v.to_string_lossy().into_owned(),
+            None => "<MISSING>".to_string(),
+        };
+        match path() {
+            None => format!("{env_name}={env_repr} path=<unresolved>"),
+            Some(p) => {
+                let (exists, bytes) = match std::fs::metadata(&p) {
+                    Ok(m) => (true, m.len()),
+                    Err(_) => (false, 0),
+                };
+                format!(
+                    "{env_name}={env_repr} path={} exists={exists} bytes={bytes}",
+                    p.display()
+                )
+            }
+        }
+    }
+}
+
+/// One-line summary of the token-store + in-memory auth state for diagnostics.
+/// `loaded_into_state` is the decisive bit: `exists=true` but
+/// `loaded_into_state=false` means the file was there but we failed to read it.
+pub fn token_probe(auth: &Mutex<AppState>) -> String {
+    let loaded = auth.lock().unwrap().token.is_some();
+    format!(
+        "{}; loaded_into_state={loaded}",
+        token_store::diagnostic_probe()
+    )
 }
 
 fn load_stored_token() -> Option<String> {
@@ -179,6 +218,7 @@ pub async fn poll_device_flow(
             TokenResponse::Success { access_token } => {
                 token_store::save(&access_token);
                 auth.lock().unwrap().token = Some(access_token);
+                crate::diagnostics::log("device-flow: token obtained and stored");
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
                     let _ = window.set_focus();
@@ -199,7 +239,11 @@ pub async fn poll_device_flow(
     }
 }
 
-pub fn clear_stored_token(auth: &Mutex<AppState>) {
+/// Clear the persisted token and the in-memory copy. `reason` is recorded in
+/// the diagnostics log so a re-auth event can be traced back to its trigger
+/// (a 401 from a specific call vs. an explicit sign-out).
+pub fn clear_stored_token(auth: &Mutex<AppState>, reason: &str) {
+    crate::diagnostics::log(&format!("token cleared: {reason}"));
     auth.lock().unwrap().token = None;
     token_store::delete();
 }
@@ -210,7 +254,7 @@ pub fn sign_out(
     bg: State<'_, crate::background::BackgroundHandle>,
     app: tauri::AppHandle,
 ) {
-    clear_stored_token(&auth);
+    clear_stored_token(&auth, "sign_out (user action)");
     bg.clear_and_notify(&app);
 }
 

--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -529,8 +529,13 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     let unauthorized = matches!(&items_res, Err(e) if e.is_unauthorized)
         || matches!(&notifs_res, Err(e) if e.is_unauthorized);
     if unauthorized {
+        let which = if matches!(&items_res, Err(e) if e.is_unauthorized) {
+            "fetch_watched"
+        } else {
+            "fetch_notifications"
+        };
         let auth = app.state::<Mutex<AppState>>();
-        clear_stored_token(&auth);
+        clear_stored_token(&auth, &format!("401 from background {which}"));
         handle.with_state(|s| s.reset_session(Some("not_authenticated".into())));
         emit_state(app, handle);
         update_tray_badge(app, handle);

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,155 @@
+//! Opt-in diagnostics log for auth/token lifecycle events.
+//!
+//! The app occasionally drops back to the sign-in screen ("re-authentication")
+//! and we want to know *why* — was the stored token actually rejected by GitHub
+//! (a real 401), or did the app simply fail to read the token file at startup
+//! (e.g. `HOME` resolving differently across launch contexts)? Those two look
+//! identical to the user but have completely different fixes.
+//!
+//! This module appends timestamped one-line events to a log file so the next
+//! occurrence is captured for inspection. It is **off by default** and gated
+//! behind a user setting; nothing is written unless the user turns it on.
+//!
+//! - Enable flag: `<config>/diagnostics` (`1` / `0`), mirroring `shortcut.rs`.
+//! - Log file: `<config>/auth-diagnostics.log`.
+//! - `<config>` is `$HOME/.config/eir` (unix) or `%APPDATA%\eir` (Windows),
+//!   the same directory the token itself lives in.
+//!
+//! Rotation keeps the log bounded: when the active file reaches
+//! [`MAX_LOG_BYTES`] it is rotated to `*.log.1` (a single backup, overwritten
+//! each rotation), capping total on-disk size at ~2×.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Rotate once the active log reaches this size; one backup is kept.
+const MAX_LOG_BYTES: u64 = 256 * 1024;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(not(windows))]
+fn config_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".config").join("eir"))
+}
+
+#[cfg(windows)]
+fn config_dir() -> Option<PathBuf> {
+    let appdata = std::env::var_os("APPDATA")?;
+    Some(PathBuf::from(appdata).join("eir"))
+}
+
+fn flag_path() -> Option<PathBuf> {
+    Some(config_dir()?.join("diagnostics"))
+}
+
+fn log_path() -> Option<PathBuf> {
+    Some(config_dir()?.join("auth-diagnostics.log"))
+}
+
+/// Load the persisted enable flag into memory. Call once at startup, before
+/// emitting any events.
+pub fn init() {
+    let enabled = flag_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false);
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Flip the flag, persist it, and bracket the change with a log line so the
+/// file itself records when capture started or stopped.
+pub fn set_enabled(enabled: bool) {
+    // Record the "stopping" line while logging is still live.
+    if !enabled {
+        log("diagnostics disabled");
+    }
+    ENABLED.store(enabled, Ordering::Relaxed);
+    if let Some(p) = flag_path() {
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(p, if enabled { "1" } else { "0" });
+    }
+    if enabled {
+        log("diagnostics enabled");
+    }
+}
+
+/// Append a timestamped event line. No-op unless diagnostics are enabled.
+pub fn log(event: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let Some(path) = log_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    rotate_if_needed(&path);
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ");
+        let _ = writeln!(file, "{ts}\t{event}");
+    }
+}
+
+/// Rotate the active log to `*.log.1` once it grows past the cap, keeping a
+/// single backup. `remove_file` first so the rename also succeeds on Windows
+/// (where renaming onto an existing path errors).
+fn rotate_if_needed(path: &Path) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return;
+    };
+    if meta.len() < MAX_LOG_BYTES {
+        return;
+    }
+    let mut backup = path.as_os_str().to_owned();
+    backup.push(".1");
+    let backup = PathBuf::from(backup);
+    let _ = std::fs::remove_file(&backup);
+    let _ = std::fs::rename(path, &backup);
+}
+
+#[tauri::command]
+pub fn get_diagnostics_enabled() -> bool {
+    is_enabled()
+}
+
+#[tauri::command]
+pub fn set_diagnostics_enabled(enabled: bool) {
+    set_enabled(enabled);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotation_renames_when_over_cap_and_keeps_single_backup() {
+        let dir = std::env::temp_dir().join(format!("eir-diag-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let log = dir.join("auth-diagnostics.log");
+
+        // Over-cap file → rotates to .1
+        std::fs::write(&log, vec![b'x'; (MAX_LOG_BYTES + 1) as usize]).unwrap();
+        rotate_if_needed(&log);
+        let backup = dir.join("auth-diagnostics.log.1");
+        assert!(backup.exists(), "backup should be created");
+        assert!(!log.exists(), "active log should have been renamed away");
+
+        // A fresh, under-cap file is left untouched.
+        std::fs::write(&log, b"small").unwrap();
+        rotate_if_needed(&log);
+        assert!(log.exists(), "small log should remain");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -840,7 +840,7 @@ pub async fn fetch_watched(
         Ok(items) => Ok(items),
         Err(err) => {
             if err.is_unauthorized {
-                clear_stored_token(&auth);
+                clear_stored_token(&auth, "401 from fetch_watched command");
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1016,7 +1016,7 @@ pub async fn fetch_item_states(
         Ok(states) => Ok(states),
         Err(err) => {
             if err.is_unauthorized {
-                clear_stored_token(&auth);
+                clear_stored_token(&auth, "401 from fetch_item_states command");
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1113,7 +1113,7 @@ pub async fn fetch_notifications(
         Ok(items) => Ok(items),
         Err(err) => {
             if err.is_unauthorized {
-                clear_stored_token(&auth);
+                clear_stored_token(&auth, "401 from fetch_notifications command");
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1147,7 +1147,7 @@ pub async fn mark_notification_read(
         Err(err) => {
             let ge = GithubError::from_octocrab(err);
             if ge.is_unauthorized {
-                clear_stored_token(&auth);
+                clear_stored_token(&auth, "401 from mark_notification_read command");
                 return Err("not_authenticated".into());
             }
             Err(ge.message)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod background;
+mod diagnostics;
 mod diff;
 mod github;
 mod settings_io;
@@ -68,10 +69,24 @@ pub fn run() {
             background::snooze_item,
             background::unsnooze_item,
             updater::relaunch_app,
+            diagnostics::get_diagnostics_enabled,
+            diagnostics::set_diagnostics_enabled,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
+            // Load the opt-in diagnostics flag, then record a startup snapshot
+            // of the token-store state. If the user has logging on, this single
+            // line distinguishes "token file missing / unreadable at launch"
+            // from "token present but later rejected" the next time the app
+            // bounces them to sign-in.
+            diagnostics::init();
+            diagnostics::log(&format!(
+                "startup: {}",
+                auth::token_probe(app.state::<Mutex<AppState>>().inner())
+            ));
+
             tray::setup(app)?;
             let stored = shortcut::load_shortcut_string();
             let parsed = shortcut::parse_shortcut(&stored)

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -23,6 +23,7 @@
     theme: Theme;
     themeOptions: { value: Theme; label: string }[];
     autostartEnabled: boolean | null;
+    diagnosticsEnabled: boolean;
     appVersion: string;
     toggleShortcut: string;
     capturingShortcut: boolean;
@@ -45,6 +46,7 @@
     onIncludeIssuesChange: (enabled: boolean) => void;
     onThemeChange: (value: Theme) => void;
     onToggleAutostart: (enabled: boolean) => void;
+    onDiagnosticsChange: (enabled: boolean) => void;
     onSendTestNotification: () => void;
     onRunUpdateCheck: () => void;
     onInstallUpdate: () => void;
@@ -68,6 +70,7 @@
     theme,
     themeOptions,
     autostartEnabled,
+    diagnosticsEnabled,
     appVersion,
     toggleShortcut,
     capturingShortcut,
@@ -90,6 +93,7 @@
     onIncludeIssuesChange,
     onThemeChange,
     onToggleAutostart,
+    onDiagnosticsChange,
     onSendTestNotification,
     onRunUpdateCheck,
     onInstallUpdate,
@@ -425,6 +429,24 @@
       {#if settingsIoError}
         <p class="error">{settingsIoError}</p>
       {/if}
+    </div>
+
+    <div class="setting-section">
+      <span class="setting-label">Troubleshooting</span>
+      <label class="setting-row">
+        <span class="setting-label">Auth diagnostics log</span>
+        <input
+          type="checkbox"
+          checked={diagnosticsEnabled}
+          onchange={(e) => onDiagnosticsChange(e.currentTarget.checked)}
+        />
+      </label>
+      <p class="setting-hint">
+        Off by default. When on, records token / sign-in events (no token
+        values) to <code>~/.config/eir/auth-diagnostics.log</code> so an
+        unexpected re-authentication can be traced. The log rotates so it stays
+        small. Turn this on if you keep getting signed out.
+      </p>
     </div>
 
     <div class="setting-section">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -160,6 +160,7 @@
   let updateStatus = $state<UpdateStatus>({ kind: "idle" });
   let appVersion = $state<string>("");
   let autostartEnabled = $state<boolean | null>(null);
+  let diagnosticsEnabled = $state<boolean>(false);
   const repoSettings = new SvelteMap<string, RepoSetting>(
     Object.entries(loadRepoSettings()),
   );
@@ -334,6 +335,15 @@
     }
   }
 
+  async function onDiagnosticsChange(enabled: boolean) {
+    diagnosticsEnabled = enabled;
+    try {
+      await invoke("set_diagnostics_enabled", { enabled });
+    } catch (e) {
+      console.warn("[eir] set_diagnostics_enabled failed:", e);
+    }
+  }
+
   async function withPinnedWindow<T>(fn: () => Promise<T>): Promise<T> {
     // Pin the popup (so focus loss doesn't auto-hide it) AND drop always-on-top
     // so the native dialog can actually render above the popup instead of
@@ -501,7 +511,7 @@
     // Kick the permission dialog early so the first real notification isn't
     // also the first time the OS is asked — which silently denies in some
     // cases on macOS dev builds.
-    const [, shortcut, version, autostart] = await Promise.all([
+    const [, shortcut, version, autostart, diagnostics] = await Promise.all([
       ensureNotificationPermission().catch(() => false),
       invoke<string>("get_toggle_shortcut").catch(() => null),
       getVersion().catch(() => ""),
@@ -509,10 +519,12 @@
       // reads the LaunchAgent plist, so this catches changes made outside
       // the app (e.g. the user disabled "Login Items" in System Settings).
       isAutostartEnabled().catch(() => false),
+      invoke<boolean>("get_diagnostics_enabled").catch(() => false),
     ]);
     if (shortcut) toggleShortcut = shortcut;
     appVersion = version;
     autostartEnabled = autostart;
+    diagnosticsEnabled = diagnostics;
   });
 
   onDestroy(() => {
@@ -1307,6 +1319,7 @@
       {theme}
       themeOptions={THEME_OPTIONS}
       {autostartEnabled}
+      {diagnosticsEnabled}
       {appVersion}
       {toggleShortcut}
       {capturingShortcut}
@@ -1329,6 +1342,7 @@
       {onIncludeIssuesChange}
       {onThemeChange}
       onToggleAutostart={toggleAutostart}
+      {onDiagnosticsChange}
       onSendTestNotification={sendTestNotification}
       onRunUpdateCheck={() => runUpdateCheck({ interactive: true })}
       onInstallUpdate={installPendingUpdate}


### PR DESCRIPTION
## Summary

Adds an **opt-in** diagnostics log for auth/token lifecycle events so an unexpected re-authentication can be traced to its actual cause. Re-auth ("signed out unexpectedly") and a missing token at startup look identical to the user but have different fixes — a real GitHub 401 vs. failing to read the token file at launch (e.g. `HOME` resolving differently across launch contexts). This log tells them apart.

## Changes

- **New `diagnostics` module**: appends timestamped, non-sensitive one-line events to `<config>/auth-diagnostics.log`. **Off by default**, gated behind a persisted flag (`<config>/diagnostics`) that mirrors `shortcut.rs` so it's readable at startup before the frontend loads. Single-backup size rotation (256 KiB) keeps the file bounded.
- **Startup probe**: records whether `HOME`/`APPDATA` resolved, the token path, and whether the file existed vs. was actually loaded into state — the decisive signal for the "file there but unreadable" case. Never logs the token value.
- **Reasoned token clears**: `clear_stored_token` now takes a `reason`, logged so a re-auth traces back to its trigger (which 401 / which call, or explicit sign-out). Token acquisition is logged too.
- **Settings UI**: new "Troubleshooting → Auth diagnostics log" toggle wired to `get/set_diagnostics_enabled`, with a hint pointing at the log path.
- Adds `chrono` (already in the tree transitively) as a direct dependency for readable UTC timestamps.

## Verification

- `pnpm check` 0 errors / `pnpm test` 46 passed
- `cargo fmt --check` OK / `cargo test --lib` 125 passed (added a rotation unit test)
- clippy clean on the changed files

## How to use

Enable the toggle, keep using the app; on the next unexpected sign-out, inspect `~/.config/eir/auth-diagnostics.log` — the `startup:` and `token cleared:` lines distinguish a local token-read failure from a real 401 revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G4Yiw9Uba5gZusSHyx3sL

---
_Generated by [Claude Code](https://claude.ai/code/session_014G4Yiw9Uba5gZusSHyx3sL)_