### PR TITLE
Verify 401s with GET /user before clearing the stored token

### DIFF
--- a/src-tauri/src/background.rs
+++ b/src-tauri/src/background.rs
@@ -8,11 +8,11 @@ use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_notification::NotificationExt;
 use tokio::sync::Notify;
 
-use crate::auth::{clear_stored_token, AppState};
+use crate::auth::AppState;
 use crate::diff::{compute_item_changes, fresh_notifications, item_key, removed_items};
 use crate::github::{
-    build_octocrab, fetch_item_states_with, fetch_notifications_with, fetch_watched_with, ItemRef,
-    LatestComment, NotificationItem, WatchedItem,
+    build_octocrab, clear_token_if_dead, fetch_item_states_with, fetch_notifications_with,
+    fetch_watched_with, GithubError, ItemRef, LatestComment, NotificationItem, WatchedItem,
 };
 use crate::snooze::{self, SnoozedMap};
 
@@ -526,7 +526,11 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
     )
     .await;
 
-    // 401 on either call → clear the persisted token and bail.
+    // 401 on either call → re-verify the token before treating it as dead.
+    // GitHub has returned transient 401s here (2026-07-13: notifications
+    // 401'd while the search call in the same cycle succeeded), and clearing
+    // on a single one signs the user out spuriously. Both outcomes are logged
+    // so the diagnostics log shows whether the 401 hit one call or both.
     let unauthorized = matches!(&items_res, Err(e) if e.is_unauthorized)
         || matches!(&notifs_res, Err(e) if e.is_unauthorized);
     if unauthorized {
@@ -535,12 +539,24 @@ async fn run_cycle(app: &AppHandle, handle: &BackgroundHandle) {
         } else {
             "fetch_notifications"
         };
+        crate::diagnostics::log(&format!(
+            "401 in background cycle: fetch_watched={} fetch_notifications={}",
+            fetch_outcome(&items_res),
+            fetch_outcome(&notifs_res),
+        ));
         let auth = app.state::<Mutex<AppState>>();
-        clear_stored_token(&auth, &format!("401 from background {which}"));
-        handle.with_state(|s| s.reset_session(Some("not_authenticated".into())));
-        emit_state(app, handle);
-        update_tray_badge(app, handle);
-        return;
+        if clear_token_if_dead(&auth, &octo, &format!("background {which}")).await {
+            handle.with_state(|s| s.reset_session(Some("not_authenticated".into())));
+            emit_state(app, handle);
+            update_tray_badge(app, handle);
+            return;
+        }
+        let message = match (&items_res, &notifs_res) {
+            (Err(e), _) if e.is_unauthorized => e.message.clone(),
+            (_, Err(e)) => e.message.clone(),
+            _ => "unauthorized".into(),
+        };
+        return fail_cycle(app, handle, message);
     }
 
     let items = match items_res {
@@ -771,6 +787,45 @@ where
         items_res.expect("items future awaited"),
         notifs_res.expect("notifications future awaited"),
     )
+}
+
+/// One-word-ish summary of a fetch result for the auth diagnostics log, so a
+/// 401 line records whether the sibling call in the same cycle also failed.
+fn fetch_outcome<T>(res: &Result<T, GithubError>) -> String {
+    match res {
+        Ok(_) => "ok".into(),
+        Err(e) if e.is_unauthorized => "401".into(),
+        Err(e) => format!("err({})", e.message.chars().take(200).collect::<String>()),
+    }
+}
+
+#[cfg(test)]
+mod fetch_outcome_tests {
+    use super::*;
+
+    fn unauthorized() -> GithubError {
+        GithubError {
+            message: "GitHub: Bad credentials".into(),
+            is_unauthorized: true,
+        }
+    }
+
+    #[test]
+    fn summarizes_ok_401_and_other_errors() {
+        assert_eq!(fetch_outcome(&Ok(())), "ok");
+        assert_eq!(fetch_outcome::<()>(&Err(unauthorized())), "401");
+        assert_eq!(
+            fetch_outcome::<()>(&Err(GithubError::other("boom"))),
+            "err(boom)"
+        );
+    }
+
+    #[test]
+    fn truncates_long_error_messages() {
+        let long = "x".repeat(500);
+        let out = fetch_outcome::<()>(&Err(GithubError::other(long)));
+        assert_eq!(out.len(), "err()".len() + 200);
+    }
 }
 
 fn fail_cycle(app: &AppHandle, handle: &BackgroundHandle, message: String) {

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -82,6 +82,8 @@ pub fn set_enabled(enabled: bool) {
 }
 
 /// Append a timestamped event line. No-op unless diagnostics are enabled.
+/// Events may embed upstream error messages, so newlines are flattened to
+/// keep the one-event-per-line format parseable.
 pub fn log(event: &str) {
     if !is_enabled() {
         return;
@@ -97,8 +99,12 @@ pub fn log(event: &str) {
         .open(&path)
     {
         let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ");
-        let _ = writeln!(file, "{ts}\t{event}");
+        let _ = writeln!(file, "{ts}\t{}", flatten_to_one_line(event));
     }
+}
+
+fn flatten_to_one_line(event: &str) -> String {
+    event.replace(['\n', '\r'], " ")
 }
 
 /// Rotate the active log to `*.log.1` once it grows past the cap, keeping a
@@ -131,6 +137,14 @@ pub fn set_diagnostics_enabled(enabled: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn flatten_replaces_newlines_so_events_stay_one_line() {
+        assert_eq!(
+            flatten_to_one_line("graphql error:\r\nline two\nline three"),
+            "graphql error:  line two line three"
+        );
+    }
 
     #[test]
     fn rotation_renames_when_over_cap_and_keeps_single_backup() {

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -36,6 +36,62 @@ impl GithubError {
     }
 }
 
+/// Outcome of re-checking the stored token after some call returned 401.
+enum TokenCheck {
+    Valid,
+    Unauthorized,
+    Inconclusive(String),
+}
+
+/// `GET /user` with the same client that just got the 401 — the cheapest
+/// authenticated call there is; its verdict decides whether the 401 was real.
+async fn verify_token(octo: &octocrab::Octocrab) -> TokenCheck {
+    match octo.current().user().await {
+        Ok(_) => TokenCheck::Valid,
+        Err(err) => {
+            let ge = GithubError::from_octocrab(err);
+            if ge.is_unauthorized {
+                TokenCheck::Unauthorized
+            } else {
+                TokenCheck::Inconclusive(ge.message)
+            }
+        }
+    }
+}
+
+/// A call returned 401. GitHub has been observed to return a transient 401
+/// for a token that is still valid (2026-07-13: the notifications endpoint
+/// 401'd while the search call in the same cycle succeeded), so a single 401
+/// is not proof the credential is dead. Re-verify with `GET /user` and clear
+/// the persisted token only when that confirms it; on a transient or
+/// inconclusive verdict the token is kept and the caller should surface an
+/// ordinary error so the next cycle retries. Returns whether the token was
+/// cleared. Every path logs its verdict to the auth diagnostics log.
+pub async fn clear_token_if_dead(
+    auth: &Mutex<AppState>,
+    octo: &octocrab::Octocrab,
+    context: &str,
+) -> bool {
+    match verify_token(octo).await {
+        TokenCheck::Unauthorized => {
+            clear_stored_token(auth, &format!("401 from {context}, confirmed by GET /user"));
+            true
+        }
+        TokenCheck::Valid => {
+            crate::diagnostics::log(&format!(
+                "401 from {context} but GET /user succeeded; treating as transient, token kept"
+            ));
+            false
+        }
+        TokenCheck::Inconclusive(msg) => {
+            crate::diagnostics::log(&format!(
+                "401 from {context}, GET /user inconclusive ({msg}); token kept"
+            ));
+            false
+        }
+    }
+}
+
 pub fn build_octocrab(token: &str) -> Result<octocrab::Octocrab, String> {
     octocrab::OctocrabBuilder::new()
         .personal_token(token.to_string())
@@ -839,8 +895,9 @@ pub async fn fetch_watched(
     match fetch_watched_with(&octo, &tab, &orgs, &settings, prs, issues).await {
         Ok(items) => Ok(items),
         Err(err) => {
-            if err.is_unauthorized {
-                clear_stored_token(&auth, "401 from fetch_watched command");
+            if err.is_unauthorized
+                && clear_token_if_dead(&auth, &octo, "fetch_watched command").await
+            {
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1015,8 +1072,9 @@ pub async fn fetch_item_states(
     match fetch_item_states_with(&octo, &items).await {
         Ok(states) => Ok(states),
         Err(err) => {
-            if err.is_unauthorized {
-                clear_stored_token(&auth, "401 from fetch_item_states command");
+            if err.is_unauthorized
+                && clear_token_if_dead(&auth, &octo, "fetch_item_states command").await
+            {
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1112,8 +1170,9 @@ pub async fn fetch_notifications(
     match fetch_notifications_with(&octo).await {
         Ok(items) => Ok(items),
         Err(err) => {
-            if err.is_unauthorized {
-                clear_stored_token(&auth, "401 from fetch_notifications command");
+            if err.is_unauthorized
+                && clear_token_if_dead(&auth, &octo, "fetch_notifications command").await
+            {
                 return Err("not_authenticated".into());
             }
             Err(err.message)
@@ -1146,8 +1205,9 @@ pub async fn mark_notification_read(
         }
         Err(err) => {
             let ge = GithubError::from_octocrab(err);
-            if ge.is_unauthorized {
-                clear_stored_token(&auth, "401 from mark_notification_read command");
+            if ge.is_unauthorized
+                && clear_token_if_dead(&auth, &octo, "mark_notification_read command").await
+            {
                 return Err("not_authenticated".into());
             }
             Err(ge.message)


### PR DESCRIPTION
## Summary

The opt-in auth diagnostics log (#104) captured the 2026-07-13 spurious sign-out:

```
2026-07-13T12:32:49.949Z  token cleared: 401 from background fetch_notifications
```

Every startup line before it showed the token loading fine (`exists=true; loaded_into_state=true`), ruling out the token-file-read hypothesis. And since a 401 on `fetch_watched` takes precedence in that log line, the search call in the **same cycle with the same token did not 401** — strong evidence of a transient GitHub-side 401 on the notifications endpoint, not a dead credential. One transient 401 was enough to throw the user back to the sign-in screen.

## Changes

- **`github.rs`: new `clear_token_if_dead`** — on a 401, re-verify the token with `GET /user` (cheapest authenticated call, same client) and clear it only when the check confirms the 401:
  - `GET /user` → 401: credential is really dead → clear token, sign out (logged as `..., confirmed by GET /user`)
  - `GET /user` → ok: transient 401 → keep the token, surface an ordinary error; the next cycle retries
  - `GET /user` → other error: inconclusive → keep the token (a genuinely dead token will re-401 next cycle and get confirmed then)

  All five 401 paths (background worker + `fetch_watched` / `fetch_item_states` / `fetch_notifications` / `mark_notification_read` commands) go through it, and every verdict is written to the diagnostics log.
- **`background.rs`: richer diagnostics on 401** — the 401 branch now logs both fetch outcomes of the cycle (`401 in background cycle: fetch_watched=ok fetch_notifications=401`), so the next occurrence directly records whether the 401 hit one call or both.
- **`diagnostics.rs`: one-line invariant** — newlines in event text (e.g. embedded GraphQL error messages) are flattened so the log stays one event per line.

## Test plan

- `cargo test --lib` — 128 passed (adds tests for the outcome summary and newline flattening)
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt` — clean
- Real-world validation waits for the next 401 in the wild: a transient one should now show an error banner and self-recover on the next cycle instead of signing out, with the full verdict trail in `~/.config/eir/auth-diagnostics.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)